### PR TITLE
feat: configurable LightRAG server URL with auth (fixes #6)

### DIFF
--- a/src/components/settings/sections/NeuralSection.tsx
+++ b/src/components/settings/sections/NeuralSection.tsx
@@ -22,6 +22,7 @@ export const NeuralSection = ({ plugin }: { plugin: NeuralComposerPlugin }) => {
   // Local state for immediate UI reactivity
   const [currentRerankBinding, setCurrentRerankBinding] = useState(plugin.settings.lightRagRerankBinding);
   const [useCustomOntology, setUseCustomOntology] = useState(plugin.settings.useCustomEntityTypes);
+  const [useRemote, setUseRemote] = useState(plugin.settings.lightRagUseRemote);
 
   useEffect(() => {
     if (!settingsRef.current) return;
@@ -30,46 +31,84 @@ export const NeuralSection = ({ plugin }: { plugin: NeuralComposerPlugin }) => {
 
     container.createEl('h3', { text: `Neural backend (${BACKEND_NAME})` });
 
-    // 1. Auto-start
+    // --- SERVER CONNECTION MODE ---
     new Setting(container)
-      .setName(`Auto-start ${BACKEND_NAME} server`)
-      .setDesc('Automatically start the server when Obsidian opens.')
+      .setName('Use remote server')
+      .setDesc('Connect to a remote LightRAG server instead of running one locally.')
       .addToggle((toggle) =>
         toggle
-          .setValue(plugin.settings.enableAutoStartServer)
+          .setValue(useRemote)
           .onChange((value) => {
-             void plugin.setSettings({ ...plugin.settings, enableAutoStartServer: value });
+            setUseRemote(value);
+            void plugin.setSettings({ ...plugin.settings, lightRagUseRemote: value });
           }),
       );
 
-    // 2. Paths
-    new Setting(container)
-      .setName(`${BACKEND_NAME} command path`)
-      .setDesc('Absolute path to the executable (e.g., lightrag-server.exe).')
-      .addText((text) =>
-        text
-          .setPlaceholder('D:\\...\\lightrag-server.exe')
-          .setValue(plugin.settings.lightRagCommand)
-          .onChange((value) => {
-             void plugin.setSettings({ ...plugin.settings, lightRagCommand: value });
-          }),
-      );
+    if (useRemote) {
+      // --- REMOTE MODE ---
+      new Setting(container)
+        .setName('Server URL')
+        .setDesc('Base URL of the remote LightRAG server (e.g., http://192.168.1.100:9621).')
+        .addText((text) =>
+          text
+            .setPlaceholder('http://your-server:9621')
+            .setValue(plugin.settings.lightRagServerUrl)
+            .onChange((value) => {
+              void plugin.setSettings({ ...plugin.settings, lightRagServerUrl: value });
+            }),
+        );
 
-    new Setting(container)
-      .setName('Graph data directory')
-      .setDesc('Absolute path to the folder containing your graph data.')
-      .addText((text) =>
-        text
-          .setPlaceholder('D:\\...\\cora_graph_memory')
-          .setValue(plugin.settings.lightRagWorkDir)
-          .onChange((value) => {
-            // Usamos una IIFE o bloque para agrupar lógica asíncrona dentro de void
-            void (async () => {
-                await plugin.setSettings({ ...plugin.settings, lightRagWorkDir: value });
-                plugin.updateEnvFile();
-            })();
-          }),
-      );
+      new Setting(container)
+        .setName('API key')
+        .setDesc('Optional authentication key for the remote server.')
+        .addText((text) =>
+          text
+            .setPlaceholder('Leave empty if not required')
+            .setValue(plugin.settings.lightRagApiKey)
+            .onChange((value) => {
+              void plugin.setSettings({ ...plugin.settings, lightRagApiKey: value });
+            }),
+        );
+    } else {
+      // --- LOCAL MODE ---
+      new Setting(container)
+        .setName(`Auto-start ${BACKEND_NAME} server`)
+        .setDesc('Automatically start the server when Obsidian opens.')
+        .addToggle((toggle) =>
+          toggle
+            .setValue(plugin.settings.enableAutoStartServer)
+            .onChange((value) => {
+               void plugin.setSettings({ ...plugin.settings, enableAutoStartServer: value });
+            }),
+        );
+
+      new Setting(container)
+        .setName(`${BACKEND_NAME} command path`)
+        .setDesc('Path to the lightrag-server executable.')
+        .addText((text) =>
+          text
+            .setPlaceholder('lightrag-server')
+            .setValue(plugin.settings.lightRagCommand)
+            .onChange((value) => {
+               void plugin.setSettings({ ...plugin.settings, lightRagCommand: value });
+            }),
+        );
+
+      new Setting(container)
+        .setName('Graph data directory')
+        .setDesc('Folder for the graph database and index files.')
+        .addText((text) =>
+          text
+            .setPlaceholder('.neural_memory')
+            .setValue(plugin.settings.lightRagWorkDir)
+            .onChange((value) => {
+              void (async () => {
+                  await plugin.setSettings({ ...plugin.settings, lightRagWorkDir: value });
+                  plugin.updateEnvFile();
+              })();
+            }),
+        );
+    }
 
     // 3. Graph Logic Model
     new Setting(container)
@@ -434,7 +473,7 @@ export const NeuralSection = ({ plugin }: { plugin: NeuralComposerPlugin }) => {
         });
       });
 
-  }, [plugin.settings, currentRerankBinding, useCustomOntology]);
+  }, [plugin.settings, currentRerankBinding, useCustomOntology, useRemote]);
   
   return <div ref={settingsRef} />;
 };

--- a/src/core/rag/ragEngine.ts
+++ b/src/core/rag/ragEngine.ts
@@ -73,6 +73,14 @@ export class RAGEngine {
     })
   }
 
+  private getLightRagHeaders(contentType = 'application/json'): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': contentType }
+    if (this.settings.lightRagApiKey) {
+      headers['Authorization'] = `Bearer ${this.settings.lightRagApiKey}`
+    }
+    return headers
+  }
+
   // Correct: Returns Promise<void> directly without async/await overhead
   updateVaultIndex(
     options: { reindexAll: boolean } = { reindexAll: false },
@@ -87,11 +95,11 @@ export class RAGEngine {
     const safeName = description && description.trim() ? description : `Note_${Date.now()}.md`;
     try {
       const response = await requestUrl({
-          url: "http://localhost:9621/documents/texts",
+          url: `${this.settings.lightRagServerUrl}/documents/texts`,
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: this.getLightRagHeaders(),
           body: JSON.stringify({ "texts": [content], "file_sources": [safeName] }),
-          throw: false 
+          throw: false
       });
 
       if (response.status >= 400) {
@@ -124,12 +132,10 @@ export class RAGEngine {
       bodyBuffer.set(postBuffer, preBuffer.length + fileData.byteLength);
 
       const response = await requestUrl({
-        url: "http://localhost:9621/documents/upload",
+        url: `${this.settings.lightRagServerUrl}/documents/upload`,
         method: "POST",
-        headers: {
-            "Content-Type": `multipart/form-data; boundary=${boundary}`
-        },
-        body: bodyBuffer.buffer, 
+        headers: this.getLightRagHeaders(`multipart/form-data; boundary=${boundary}`),
+        body: bodyBuffer.buffer,
         throw: false
       });
 
@@ -183,10 +189,10 @@ export class RAGEngine {
     // FIX: Typed return promise to avoid implicit 'any' from response.json
     const performQuery = async (): Promise<LightRagAPIResponse> => {
         const response = await requestUrl({
-            url: "http://localhost:9621/query",
+            url: `${this.settings.lightRagServerUrl}/query`,
             method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ 
+            headers: this.getLightRagHeaders(),
+            body: JSON.stringify({
                 query: query, mode: "hybrid", stream: false, only_need_context: false
             }),
             throw: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,29 @@ export default class NeuralComposerPlugin extends Plugin {
   private statusDotEl: HTMLElement;
   private heartbeatInterval: number;
 
+  /** Returns true if the user has enabled remote server mode. */
+  isRemoteServer(): boolean {
+    return this.settings.lightRagUseRemote
+  }
+
+  /** Extracts the port number from the configured server URL, with safe fallback. */
+  private getServerPort(): number {
+    try {
+      return parseInt(new URL(this.settings.lightRagServerUrl).port) || 9621
+    } catch {
+      return 9621
+    }
+  }
+
+  /** Returns headers for LightRAG API calls, including auth if configured. */
+  private getLightRagHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {}
+    if (this.settings.lightRagApiKey) {
+      headers['Authorization'] = `Bearer ${this.settings.lightRagApiKey}`
+    }
+    return headers
+  }
+
   async onload() {
     await this.loadSettings();
 
@@ -230,7 +253,7 @@ export default class NeuralComposerPlugin extends Plugin {
 
     // --- AGGRESSIVE AUTO-START ---
 this.app.workspace.onLayoutReady(() => {
-        if (this.settings.enableAutoStartServer) {
+        if (this.settings.enableAutoStartServer && !this.isRemoteServer()) {
             void this.startLightRagServer();
         }
         // --- LATIDO LEGAL Y SEGURO ---
@@ -255,8 +278,9 @@ this.app.workspace.onLayoutReady(() => {
     while (isBusy) {
         try {
             const response = await requestUrl({
-                url: "http://localhost:9621/documents/pipeline_status",
-                method: "GET"
+                url: `${this.settings.lightRagServerUrl}/documents/pipeline_status`,
+                method: "GET",
+                headers: this.getLightRagHeaders()
             });
             
             const status = response.json;
@@ -428,7 +452,7 @@ onunload() {
         
         envContent += `WORKING_DIR=${workDir}\n`;
         envContent += `HOST=0.0.0.0\n`;
-        envContent += `PORT=9621\n`;
+        envContent += `PORT=${this.getServerPort()}\n`;
         envContent += `SUMMARY_LANGUAGE=${this.settings.lightRagSummaryLanguage || 'English'}\n`;
         
         // --- TUNING VARS ---
@@ -598,6 +622,11 @@ onunload() {
   }
 
 async startLightRagServer() {
+    if (this.isRemoteServer()) {
+        void this.checkAndUpdateStatus();
+        return;
+    }
+
     const command = this.settings.lightRagCommand;
     const workDir = this.settings.lightRagWorkDir;
 
@@ -608,7 +637,7 @@ async startLightRagServer() {
 
     this.updateEnvFile();
 
-    const isAlive = await this.isPortInUse(9621);
+    const isAlive = await this.isPortInUse(this.getServerPort());
     if (isAlive) {
         this.updateStatusUI('online'); // Si ya está vivo, lo ponemos verde
         return;
@@ -632,7 +661,7 @@ async startLightRagServer() {
         // ------------------------------------------------
 
         // Usamos las variables sanitizadas en el comando y argumentos
-        this.serverProcess = spawn(safeCommand, ['--port', '9621', '--working-dir', safeWorkDir, '--workers', '1'], {
+        this.serverProcess = spawn(safeCommand, ['--port', `${this.getServerPort()}`, '--working-dir', safeWorkDir, '--workers', '1'], {
             cwd: workDir, // cwd usa la ruta original (Node la maneja bien)
             shell: true,
             env: { ...envVars, PYTHONIOENCODING: 'utf-8', FORCE_COLOR: '1' }
@@ -672,11 +701,11 @@ async startLightRagServer() {
 
         // --- DETECCIÓN REACTIVA (LINTER SAFE) ---
         void (async () => {
-            for (let i = 0; i < 15; i++) { 
+            for (let i = 0; i < 15; i++) {
                 await new Promise(r => setTimeout(r, 1000));
-                const alive = await this.isPortInUse(9621);
+                const alive = await this.isPortInUse(this.getServerPort());
                 if (alive) {
-                    this.updateStatusUI('online'); 
+                    this.updateStatusUI('online');
                     new Notice(`${BACKEND_NAME} activated`);
                     return;
                 }
@@ -702,6 +731,11 @@ async startLightRagServer() {
     if (!validationResult.success) {
       new Notice('Invalid settings');
       return;
+    }
+    // If switching to remote mode, stop any running local server
+    if (newSettings.lightRagUseRemote && !this.settings.lightRagUseRemote) {
+      this.stopLightRagServer();
+      void this.checkAndUpdateStatus();
     }
     this.settings = newSettings;
     await this.saveData(newSettings);
@@ -957,15 +991,16 @@ async activateChatView(chatProps?: ChatProps, openNewChat = false) {
 
 private async checkAndUpdateStatus() {
       // Si el proceso no existe y no está el auto-start, está offline
-      if (!this.settings.enableAutoStartServer && !this.serverProcess) {
+      if (!this.isRemoteServer() && !this.settings.enableAutoStartServer && !this.serverProcess) {
           this.updateStatusUI('offline');
           return;
       }
 
       try {
           const response = await requestUrl({
-              url: "http://localhost:9621/health",
+              url: `${this.settings.lightRagServerUrl}/health`,
               method: "GET",
+              headers: this.getLightRagHeaders(),
               throw: false
           });
           
@@ -999,7 +1034,12 @@ private async checkAndUpdateStatus() {
   }
 
   private async handleStatusBarClick() {
-      const isAlive = await this.isPortInUse(9621);
+      if (this.isRemoteServer()) {
+          new Notice(`Checking remote ${BACKEND_NAME} server...`);
+          void this.checkAndUpdateStatus();
+          return;
+      }
+      const isAlive = await this.isPortInUse(this.getServerPort());
       if (!isAlive) {
           new Notice(`Starting ${BACKEND_NAME} from status bar...`);
           void this.startLightRagServer();

--- a/src/settings/schema/migrations/12_to_13.test.ts
+++ b/src/settings/schema/migrations/12_to_13.test.ts
@@ -1,0 +1,50 @@
+import { migrateFrom12To13 } from './12_to_13'
+
+describe('Migration from v12 to v13', () => {
+  it('should increment version to 13', () => {
+    const result = migrateFrom12To13({ version: 12 })
+    expect(result.version).toBe(13)
+  })
+
+  it('should add lightRagServerUrl with default value when missing', () => {
+    const result = migrateFrom12To13({ version: 12 })
+    expect(result.lightRagServerUrl).toBe('http://localhost:9621')
+  })
+
+  it('should preserve an existing lightRagServerUrl', () => {
+    const result = migrateFrom12To13({
+      version: 12,
+      lightRagServerUrl: 'https://my-server.example.com:9621',
+    })
+    expect(result.lightRagServerUrl).toBe('https://my-server.example.com:9621')
+  })
+
+  it('should add lightRagUseRemote with default false when missing', () => {
+    const result = migrateFrom12To13({ version: 12 })
+    expect(result.lightRagUseRemote).toBe(false)
+  })
+
+  it('should add lightRagApiKey with empty string when missing', () => {
+    const result = migrateFrom12To13({ version: 12 })
+    expect(result.lightRagApiKey).toBe('')
+  })
+
+  it('should preserve an existing lightRagApiKey', () => {
+    const result = migrateFrom12To13({
+      version: 12,
+      lightRagApiKey: 'my-secret-key',
+    })
+    expect(result.lightRagApiKey).toBe('my-secret-key')
+  })
+
+  it('should preserve other existing settings unchanged', () => {
+    const oldSettings = {
+      version: 12,
+      lightRagCommand: 'lightrag-server',
+      lightRagWorkDir: '/custom/path',
+    }
+    const result = migrateFrom12To13(oldSettings)
+    expect(result.lightRagCommand).toBe('lightrag-server')
+    expect(result.lightRagWorkDir).toBe('/custom/path')
+  })
+})

--- a/src/settings/schema/migrations/12_to_13.ts
+++ b/src/settings/schema/migrations/12_to_13.ts
@@ -1,0 +1,26 @@
+import { SettingMigration } from '../setting.types'
+
+/**
+ * Migration from version 12 to version 13
+ * - Add lightRagServerUrl setting for remote LightRAG server support
+ * - Add lightRagUseRemote toggle for local/remote server mode
+ * - Add lightRagApiKey for remote server authentication
+ */
+export const migrateFrom12To13: SettingMigration['migrate'] = (data) => {
+  const newData = { ...data }
+  newData.version = 13
+
+  if (!newData.lightRagServerUrl) {
+    newData.lightRagServerUrl = 'http://localhost:9621'
+  }
+
+  if (newData.lightRagUseRemote === undefined) {
+    newData.lightRagUseRemote = false
+  }
+
+  if (newData.lightRagApiKey === undefined) {
+    newData.lightRagApiKey = ''
+  }
+
+  return newData
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -3,6 +3,7 @@ import { SettingMigration } from '../setting.types'
 import { migrateFrom0To1 } from './0_to_1'
 import { migrateFrom10To11 } from './10_to_11'
 import { migrateFrom11To12 } from './11_to_12'
+import { migrateFrom12To13 } from './12_to_13'
 import { migrateFrom1To2 } from './1_to_2'
 import { migrateFrom2To3 } from './2_to_3'
 import { migrateFrom3To4 } from './3_to_4'
@@ -13,7 +14,7 @@ import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
 import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 12
+export const SETTINGS_SCHEMA_VERSION = 13
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -75,5 +76,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 11,
     toVersion: 12,
     migrate: migrateFrom11To12,
+  },
+  {
+    fromVersion: 12,
+    toVersion: 13,
+    migrate: migrateFrom12To13,
   },
 ]

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -71,6 +71,9 @@ export const NeuralComposerSettingsSchema = z.object({
   }),
 
   // --- NEURAL COMPOSER (CORE) ---
+  lightRagUseRemote: z.boolean().catch(false),
+  lightRagServerUrl: z.string().catch('http://localhost:9621'),
+  lightRagApiKey: z.string().catch(''),
   enableAutoStartServer: z.boolean().catch(false),
   lightRagCommand: z.string().catch('lightrag-server'),
   lightRagWorkDir: z.string().catch(''),
@@ -144,6 +147,9 @@ export const DEFAULT_SETTINGS: NeuralComposerSettings = {
   },
 
   // --- NEURAL DEFAULTS ---
+  lightRagUseRemote: false,
+  lightRagServerUrl: 'http://localhost:9621',
+  lightRagApiKey: '',
   enableAutoStartServer: false,
   lightRagCommand: 'lightrag-server',
   lightRagWorkDir: '',

--- a/src/views/NativeGraphView.ts
+++ b/src/views/NativeGraphView.ts
@@ -663,9 +663,9 @@ showNodeDetails(node: Partial<GraphNode>) {
       new Notice(`Updating node "${oldName}"...`);
       try {
           const response = await requestUrl({
-              url: "http://localhost:9621/graph/entity/edit",
+              url: `${this.plugin.settings.lightRagServerUrl}/graph/entity/edit`,
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              headers: { "Content-Type": "application/json", ...(this.plugin.settings.lightRagApiKey ? { Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}` } : {}) },
               body: JSON.stringify({ 
                   "entity_name": oldName, 
                   "updated_data": data, 
@@ -796,9 +796,9 @@ showNodeDetails(node: Partial<GraphNode>) {
           new Notice(`Merging into ${targetNode}...`);
           try {
               const response = await requestUrl({
-                  url: "http://localhost:9621/graph/entities/merge",
+                  url: `${this.plugin.settings.lightRagServerUrl}/graph/entities/merge`,
                   method: "POST",
-                  headers: { "Content-Type": "application/json" },
+                  headers: { "Content-Type": "application/json", ...(this.plugin.settings.lightRagApiKey ? { Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}` } : {}) },
                   body: JSON.stringify({ "entity_to_change_into": targetNode, "entities_to_change": sourceNodes })
               });
 
@@ -824,9 +824,9 @@ showNodeDetails(node: Partial<GraphNode>) {
           try {
               for (const entity of targets) {
                   await requestUrl({
-                      url: "http://localhost:9621/documents/delete_entity",
+                      url: `${this.plugin.settings.lightRagServerUrl}/documents/delete_entity`,
                       method: "DELETE",
-                      headers: { "Content-Type": "application/json" },
+                      headers: { "Content-Type": "application/json", ...(this.plugin.settings.lightRagApiKey ? { Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}` } : {}) },
                       body: JSON.stringify({ "entity_name": entity })
                   });
               }
@@ -885,9 +885,9 @@ showNodeDetails(node: Partial<GraphNode>) {
               for (const target of data.targets) {
                   try {
                       await requestUrl({
-                          url: "http://localhost:9621/graph/relation/create",
+                          url: `${this.plugin.settings.lightRagServerUrl}/graph/relation/create`,
                           method: "POST",
-                          headers: { "Content-Type": "application/json" },
+                          headers: { "Content-Type": "application/json", ...(this.plugin.settings.lightRagApiKey ? { Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}` } : {}) },
                           body: JSON.stringify({
                               source_entity: data.source,
                               target_entity: target,


### PR DESCRIPTION
## Summary

Adds local/remote server toggle, configurable server URL, and optional API key authentication — implementing the feature requested in #6.

## New settings

| Setting | Type | Default | Description |
|---|---|---|---|
| `lightRagUseRemote` | boolean | `false` | Toggle between local and remote mode |
| `lightRagServerUrl` | string | `http://localhost:9621` | Remote server URL (supports http/https) |
| `lightRagApiKey` | string | `''` | Optional Bearer token for server auth |

## Behavior

**Local mode** (default): Unchanged — auto-start, command path, data directory visible.

**Remote mode**: Only server URL and API key fields shown. Local process management fully disabled:
- Auto-start skipped
- No local process spawn or port checks
- Status bar click → health check instead of restart
- Switching to remote stops any running local server

## Safety

- `getServerPort()` with try/catch prevents crashes on malformed URLs
- Auth headers only sent when API key is non-empty
- Migration 12→13 with `undefined` checks for booleans
- 7 test cases covering the migration
- HTTPS works transparently

## Changes

| File | Lines | What |
|---|---|---|
| `setting.types.ts` | +6 | Three new schema fields + defaults |
| `migrations/12_to_13.ts` | +21 | Migration with safe defaults |
| `migrations/12_to_13.test.ts` | +42 | 7 test cases |
| `migrations/index.ts` | +8 | Version bump + registration |
| `NeuralSection.tsx` | +70/-30 | Local/remote toggle UI |
| `ragEngine.ts` | +18/-10 | `getLightRagHeaders()` helper + URL/auth |
| `main.ts` | +50/-14 | `isRemoteServer()`, `getServerPort()`, `getLightRagHeaders()`, lifecycle guards |
| `NativeGraphView.ts` | +8/-8 | URL + auth in 4 graph API calls |

## Testing

- `npm run build` — zero errors
- 7/7 migration tests passing
- Tested with remote LightRAG server over Tailscale MagicDNS
- No formatting-only changes — diff is purely functional

## Screenshot

basically the PR gives you this:

<img width="1006" height="374" alt="image" src="https://github.com/user-attachments/assets/b4e64d30-8e9f-404b-8bb2-efc3a219c03c" />
