### PR TITLE
fix: resolve CI failures from PR #23 merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-neural-composer",
-  "version": "1.1.16",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-neural-composer",
-      "version": "1.1.16",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/src/components/settings/SettingsTabRoot.tsx
+++ b/src/components/settings/SettingsTabRoot.tsx
@@ -39,12 +39,7 @@ export function SettingsTabRoot({ app, plugin }: SettingsTabRootProps) {
       >
         <ObsidianButton
           text="☕ Support Neural Composer"
-          onClick={() =>
-            window.open(
-              'https://ko-fi.com/oscampo',
-              '_blank',
-            )
-          }
+          onClick={() => window.open('https://ko-fi.com/oscampo', '_blank')}
         />
       </ObsidianSetting>
 

--- a/src/settings/schema/settings.test.ts
+++ b/src/settings/schema/settings.test.ts
@@ -65,6 +65,7 @@ describe('parseNeuralComposerSettings', () => {
       lightRagServerUrl: 'http://localhost:9621',
       lightRagShowCitations: true,
       lightRagSummaryLanguage: 'English',
+      lightRagSyncFolder: '',
       lightRagUseRemote: false,
       lightRagWorkDir: '',
       useCustomEntityTypes: false,

--- a/src/views/NativeGraphView.ts
+++ b/src/views/NativeGraphView.ts
@@ -529,7 +529,13 @@ export class NativeGraphView extends ItemView {
       const hoverShadowColor = isDark ? 'rgba(0,0,0,0.9)' : 'rgba(0,0,0,0.4)'
       const drawHover = (
         context: CanvasRenderingContext2D,
-        data: { x: number; y: number; size: number; label: string; [key: string]: unknown },
+        data: {
+          x: number
+          y: number
+          size: number
+          label: string
+          [key: string]: unknown
+        },
         settings: { labelSize: number; labelFont: string; labelWeight: string },
       ) => {
         const size = settings.labelSize
@@ -550,7 +556,9 @@ export class NativeGraphView extends ItemView {
           const boxHeight = Math.round(size + 2 * PADDING)
           const radius = Math.max(data.size, size / 2) + PADDING
           const angleRadian = Math.asin(Math.min(boxHeight / 2 / radius, 1))
-          const xDeltaCoord = Math.sqrt(Math.abs(radius ** 2 - (boxHeight / 2) ** 2))
+          const xDeltaCoord = Math.sqrt(
+            Math.abs(radius ** 2 - (boxHeight / 2) ** 2),
+          )
 
           context.beginPath()
           context.moveTo(data.x + xDeltaCoord, data.y + boxHeight / 2)
@@ -573,9 +581,14 @@ export class NativeGraphView extends ItemView {
 
         // Label text — use per-node labelColor attribute
         if (typeof data.label === 'string') {
-          const textColor = (data.labelColor as string | undefined) || labelTextColor
+          const textColor =
+            (data.labelColor as string | undefined) || labelTextColor
           context.fillStyle = textColor
-          context.fillText(data.label, data.x + data.size + 3, data.y + size / 3)
+          context.fillText(
+            data.label,
+            data.x + data.size + 3,
+            data.y + size / 3,
+          )
         }
       }
 


### PR DESCRIPTION
## Description

Fixes the CI failures introduced when PR #23 (auto-sync vault) was merged.

### Changes
- Add missing `lightRagSyncFolder: ''` default to settings test snapshot
- Fix Prettier formatting in `SettingsTabRoot.tsx` and `NativeGraphView.ts`
- Sync `package-lock.json` version from `1.1.16` to `1.2.0`

### Root cause
`lightRagSyncFolder` was added to the settings schema but the test snapshot was not updated, causing `parseNeuralComposerSettings` test to fail. The two files also had Prettier formatting inconsistencies post-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ienDpqJqa5EXAUKqnaSrm)_