### PR TITLE
fix: expose active embedding model selector in settings UI

### DIFF
--- a/src/components/settings/sections/models/EmbeddingModelsSubSection.tsx
+++ b/src/components/settings/sections/models/EmbeddingModelsSubSection.tsx
@@ -1,10 +1,15 @@
 import { Trash2 } from 'lucide-react'
 import { App, Notice } from 'obsidian'
 
-import { DEFAULT_EMBEDDING_MODELS } from '../../../../constants'
+import {
+  DEFAULT_EMBEDDING_MODELS,
+  RECOMMENDED_MODELS_FOR_EMBEDDING,
+} from '../../../../constants'
 import { useSettings } from '../../../../contexts/settings-context'
 import { getEmbeddingModelClient } from '../../../../core/rag/embedding'
 import NeuralComposerPlugin from '../../../../main'
+import { ObsidianDropdown } from '../../../common/ObsidianDropdown'
+import { ObsidianSetting } from '../../../common/ObsidianSetting'
 import { ConfirmModal } from '../../../modals/ConfirmModal'
 import { AddEmbeddingModelModal } from '../../modals/AddEmbeddingModelModal'
 
@@ -69,6 +74,29 @@ export function EmbeddingModelsSubSection({
       <div className="nrlcmp-settings-desc">
         Models used for generating embeddings for RAG
       </div>
+
+      <ObsidianSetting
+        name="Active embedding model"
+        desc="Choose the embedding model used for local RAG (smart context search)"
+      >
+        <ObsidianDropdown
+          value={settings.embeddingModelId}
+          options={Object.fromEntries(
+            settings.embeddingModels.map((embeddingModel) => [
+              embeddingModel.id,
+              `${embeddingModel.id}${RECOMMENDED_MODELS_FOR_EMBEDDING.includes(embeddingModel.id) ? ' (Recommended)' : ''}`,
+            ]),
+          )}
+          onChange={(value) => {
+            void (async () => {
+              await setSettings({
+                ...settings,
+                embeddingModelId: value,
+              })
+            })()
+          }}
+        />
+      </ObsidianSetting>
 
       <div className="nrlcmp-settings-table-container">
         <table className="nrlcmp-settings-table">


### PR DESCRIPTION
## Problem

The `embeddingModelId` setting — which controls the embedding model used by the built-in Smart Composer local RAG (PGLite vector search) — has no UI control in the settings panel.

When `RAGSection` was hidden after LightRAG became the primary RAG system, the only place this dropdown existed was silently removed. The setting still works at runtime (`RAGEngine` reads `settings.embeddingModelId` for every local vector lookup), but users have no way to change it through the UI.

This means users without an OpenAI key (e.g. those using Ollama or Gemini for embeddings) are silently broken: `embeddingModelId` defaults to `openai/text-embedding-3-small` and every smart context call fails with an auth error.

## Fix

Add an **"Active embedding model"** dropdown to `EmbeddingModelsSubSection`, directly above the embedding models table. This is the logical home for the control — users already manage which models are available here, so selecting the active one belongs in the same place.

The implementation reuses the same `ObsidianSetting` + `ObsidianDropdown` + `RECOMMENDED_MODELS_FOR_EMBEDDING` pattern that already existed in the now-hidden `RAGSection`.

## Changes

- `src/components/settings/sections/models/EmbeddingModelsSubSection.tsx`: add "Active embedding model" dropdown + import `ObsidianSetting`, `ObsidianDropdown`, `RECOMMENDED_MODELS_FOR_EMBEDDING`

No behaviour changes — only adds the missing UI control for a setting that was already being persisted and used at runtime.

## Checklist
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually

Made with [Cursor](https://cursor.com)