### PR TITLE
ci: replace version-bump PR with direct push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ permissions:
   contents: write
   id-token: write
   attestations: write
-  pull-requests: write
 
 jobs:
   build:
@@ -17,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Fetch full history so we can push back to main
+          fetch-depth: 0
+          ref: main
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -30,6 +33,14 @@ jobs:
 
       - name: Bump version
         run: npm run version $VERSION
+
+      - name: Commit version bump to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add manifest.json package.json versions.json
+          git diff --staged --quiet || git commit -m "chore: version bump ${{ env.TAG }}"
+          git push origin main
 
       - name: Build plugin
         run: |
@@ -55,16 +66,3 @@ jobs:
             main.js manifest.json styles.css 2>/dev/null || \
           gh release upload "$TAG" \
             main.js manifest.json styles.css --clobber
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: 'version bump: ${{ env.TAG }}'
-          title: 'Version bump: ${{ env.TAG }}'
-          body: |
-            Automated version bump after release ${{ env.TAG }}
-
-            This PR was automatically created by the release workflow.
-          branch: 'version-bump/${{ env.TAG }}'
-          base: 'main'
-          delete-branch: true


### PR DESCRIPTION
The peter-evans/create-pull-request action requires both the 'pull-requests: write' workflow permission AND the repository-level setting 'Allow GitHub Actions to create and approve pull requests' to be enabled. The latter is a manual toggle that caused every release to fail on the last step, forcing manual manifest.json updates.

New approach:
- Checkout main branch (not the tag SHA) so we can push back
- Run npm run version $VERSION to bump manifest.json, package.json, versions.json
- Commit directly to main with github-actions[bot] identity
- 'git diff --staged --quiet || git commit' skips the commit if nothing changed (idempotent re-runs)
- Build and create release assets as before

This eliminates the PR step entirely: no special repository settings required, no manual intervention after tagging.

https://claude.ai/code/session_018ienDpqJqa5EXAUKqnaSrm

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. If it fixes an issue or resolves a feature request, please include the link to the issue or feature request.

Note: If your changes include UI modifications, please include screenshots to help reviewers visualize the changes.

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually
