### PR TITLE
Add comprehensive wiki documentation and fix Gemini thinking mode with tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 ## 👋 Hello, Obsidian Community!
 
-We built **Neural Composer** because we love Obsidian, but we often felt limited by standard search tools. 
+We built **Neural Composer** because we love Obsidian, but we often felt limited by standard search tools.
 
-Have you ever searched for a topic in your vault and gotten a list of notes that contain the *word*, but miss the *context*? Or tried to ask an AI plugin a complex question, only for it to fail because it couldn't "see" the connections between your files?
+Have you ever searched for a topic in your vault and gotten a list of notes that contain the _word_, but miss the _context_? Or tried to ask an AI plugin a complex question, only for it to fail because it couldn't "see" the connections between your files?
 
 **We wanted a way to talk to our notes that felt like talking to someone who actually remembers them.**
 
@@ -17,13 +17,13 @@ That's why we integrated **LightRAG** (Graph-based Retrieval) into Obsidian. Unl
 
 ## 🤔 Why use Graph RAG?
 
-Standard AI search (Vector RAG) is great for finding *similar text*. But **Graph RAG** is better for finding *connected ideas*.
+Standard AI search (Vector RAG) is great for finding _similar text_. But **Graph RAG** is better for finding _connected ideas_.
 
-| Feature | Standard Vector Search | Neural Composer (Graph) |
-| :--- | :--- | :--- |
-| **How it searches** | Finds matching keywords/concepts | Follows relationships between entities |
-| **Best for** | Simple questions ("What is X?") | Complex questions ("How does X influence Y?") |
-| **Context** | Often fragmented | Holistic and interconnected |
+| Feature            | Standard Vector Search                  | Neural Composer (Graph)                      |
+| :----------------- | :-------------------------------------- | :------------------------------------------- |
+| **How it searches** | Finds matching keywords/concepts        | Follows relationships between entities       |
+| **Best for**        | Simple questions ("What is X?")         | Complex questions ("How does X influence Y?") |
+| **Context**         | Often fragmented                        | Holistic and interconnected                  |
 
 ---
 
@@ -31,10 +31,10 @@ Standard AI search (Vector RAG) is great for finding *similar text*. But **Graph
 
 We designed this to fit into different workflows. Here is how it might help you:
 
-*   **For Researchers:** If you have hundreds of papers, you can ask it to synthesize arguments across multiple authors, finding consensus or contradictions that a simple search would miss.
-*   **For Writers & DMs:** If you are building a world or a story, the graph tracks the relationships between characters and lore, helping you maintain consistency without digging through folders.
-*   **For Daily Journalers:** It connects entries from months ago to today, helping you spot patterns in your life or work that aren't obvious day-to-day.
-*   **For Project Managers:** It helps visualize dependencies between different project notes that might otherwise look like separate tasks.
+- **For Researchers:** If you have hundreds of papers, you can ask it to synthesize arguments across multiple authors, finding consensus or contradictions that a simple search would miss.
+- **For Writers & DMs:** If you are building a world or a story, the graph tracks the relationships between characters and lore, helping you maintain consistency without digging through folders.
+- **For Daily Journalers:** It connects entries from months ago to today, helping you spot patterns in your life or work that aren't obvious day-to-day.
+- **For Project Managers:** It helps visualize dependencies between different project notes that might otherwise look like separate tasks.
 
 ---
 
@@ -42,48 +42,65 @@ We designed this to fit into different workflows. Here is how it might help you:
 
 We wanted the experience to be as smooth as possible:
 
-*   **⚡ Automated Server:** No need to fiddle with terminals. The plugin handles the background Python server for you (starts and stops automatically).
-*   **Hybrid Search:** You don't have to choose. It combines Vector search with Graph traversal for the best results.
-*   **Easy Ingestion:** Right-click any folder to add your notes to the graph. It supports PDFs, DOCX, and more...  <details> <summary> Complete list of supported formats </summary> md, txt, docx, pdf, pptx, xlsx, rtf, odt, epub, html, htm, xml, json, yaml, yml, csv, tex, log, conf, ini, properties, sql, bat, sh, c, cpp, py, java, js, ts, swift, go, rb, php, css, scss, less  </details>
-*   **🔍 Transparency:** The chat shows you exactly which files and text segments were used to generate the answer (with citations like `[1]`), so you can always verify the source.
-*   **🔒 Local & Private:** You can use local models (like Ollama) for a completely offline experience, or connect to Gemini/OpenAI if you prefer.
+- **⚡ Automated Server:** No need to fiddle with terminals. The plugin handles the background Python server for you (starts and stops automatically).
+- **Hybrid Search:** You don't have to choose. It combines Vector search with Graph traversal for the best results.
+- **Easy Ingestion:** Right-click any folder to add your notes to the graph. It supports PDFs, DOCX, and more... <details> <summary> Complete list of supported formats </summary> md, txt, docx, pdf, pptx, xlsx, rtf, odt, epub, html, htm, xml, json, yaml, yml, csv, tex, log, conf, ini, properties, sql, bat, sh, c, cpp, py, java, js, ts, swift, go, rb, php, css, scss, less </details>
+- **🔍 Transparency:** The chat shows you exactly which files and text segments were used to generate the answer (with citations like `[1]`), so you can always verify the source.
+- **🔒 Local & Private:** You can use local models (like Ollama) for a completely offline experience, or connect to Gemini/OpenAI if you prefer.
+- **📂 Vault Sync & Document Status** _(v1.3+)_: Set a watched folder and your notes are automatically re-indexed whenever you save them (with a 5-second debounce to avoid hammering the server). Colored dots appear directly in the file explorer next to each note: 🟢 processed, 🟡 processing or failed, 🔵 removed from graph. The watched folder itself shows an aggregate dot so you can see the overall state at a glance.
+- **🌐 Remote Server Support** _(v1.3+)_: Not running LightRAG on your main machine? Connect the plugin to a LightRAG server running on another machine — a NAS, a VPS, or a Docker container. Toggle it on in **Settings → Graph & Vault** and enter the remote URL.
+- **🔍 Knowledge Graph Visualization** _(v1.3+)_: Explore your knowledge graph visually inside Obsidian, in 2D or 3D. **Overview mode** renders all nodes in the graph. **Explore mode** starts a BFS from any entity you pick, so you can trace how ideas connect.
+- **🤖 MCP Tools** _(v1.3+)_: Expose your graph to any MCP-compatible AI client (Claude Desktop, and others) through configurable MCP servers. Ask your favorite AI client questions that are answered straight from your vault's knowledge graph.
 
 ---
 
 ## Getting Started
 
-> Full documentation (in construction) on [wiki](https://github.com/oscampo/obsidian-neural-composer/wiki)
+> Full documentation on the [wiki](https://github.com/oscampo/obsidian-neural-composer/wiki)
 
 This plugin requires a small backend setup (Python) to run the LightRAG engine.
 
 ### 1. One-time Setup
-1.  Ensure you have **Python 3.10+** installed.
-2.  Install the engine via terminal:
-    ```bash
-    pip install "lightrag-hku[api]"
-    ```
-    *(We recommend using a virtual environment).*
+
+1. Ensure you have **Python 3.10+** installed.
+2. Install the engine via terminal:
+   ```bash
+   pip install "lightrag-hku[api]"
+   ```
+   _(We recommend using a virtual environment)._
 
 ### 2. Install the Plugin
-- Recommended: install via BRAT
+
+- Recommended: install via **BRAT**
 - Manual Installation:
-Download `main.js`, `manifest.json`, and `styles.css` from the **[Releases](../../releases)** page and place them in your `.obsidian/plugins/neural-composer` folder. Enable it in Obsidian.
+  Download `main.js`, `manifest.json`, and `styles.css` from the **[Releases](../../releases)** page and place them in your `.obsidian/plugins/neural-composer` folder. Enable it in Obsidian.
 
 ### 3. Connect & Go
-Go to **Settings > Neural Composer**.
-1.  Enter your API Keys (Gemini/OpenAI/Ollama).
-2.  In the **Neural Backend** section, paste the path to your `lightrag-server` executable and choose a folder for your data.
-3.  Turn on **Auto-start** and click **"Restart Server"**.
 
-You are ready! You can now right-click a folder to ingest your notes and start chatting with your vault.
+Go to **Settings → Neural Composer**. The settings panel has a sidebar with seven tabs.
+
+1. **Providers** tab: enter your API keys for whichever AI providers you use (OpenAI, Anthropic, Gemini, Ollama, etc.).
+2. **Models** tab: choose your chat model, apply model, and embedding model.
+3. **Graph & Vault** tab:
+   - Set the path to your `lightrag-server` executable.
+   - Choose a data directory where the graph will be stored.
+   - Optionally set a **watched folder** so notes are auto-synced whenever you save.
+4. Toggle **Auto-start** and click **Restart Server**.
+
+You are ready! Right-click any folder to ingest your notes and start chatting with your vault.
 
 ---
 
 ## 🧩 Advanced Options
 
 For those who like to tinker, we added some power features:
-*   **Custom Ontology:** Teach the graph the specific categories of your field (e.g., "Experiment", "Theorem") instead of generic ones.
-*   **Reranking:** Connect to Jina AI or a local reranker for higher precision results.
+
+- **Watched Folder & Status Dots:** Configure a folder to be automatically kept in sync with the graph. Colored dots in the file explorer show each note's current graph status (🟢 processed, 🟡 processing/failed, 🔵 removed) so you always know what's indexed.
+- **Remote Server Mode:** Point the plugin at a LightRAG instance running on a different machine (NAS, VPS, Docker). Useful for teams or for offloading processing to a more powerful box.
+- **Custom Ontology:** Teach the graph the specific categories of your field (e.g., "Experiment", "Theorem") instead of generic ones.
+- **Reranking:** Connect to Jina AI, Cohere, or a custom reranker endpoint for higher-precision results.
+- **MCP Tools Integration:** Expose your vault's knowledge graph to any MCP-compatible AI client. Configure MCP servers in the **Tools (MCP)** settings tab.
+- **Knowledge Graph Visualization:** Open an interactive 2D or 3D view of your graph from within Obsidian. Use Overview mode to see everything, or Explore mode to do a BFS walk from a specific entity.
 
 ---
 
@@ -93,11 +110,11 @@ Neural Composer is designed with privacy as a core principle. Here is an exact a
 
 ### What leaves your machine
 
-| Destination | When | Why |
-| :--- | :--- | :--- |
-| **Your AI provider** (OpenAI, Anthropic, Gemini, Groq, etc.) | Every chat message or ingestion | To generate responses and embeddings. Only the notes you explicitly ingest or attach are sent. |
-| **Your local LightRAG server** (`localhost`) | Every query and ingestion | The plugin talks to the LightRAG Python process running on your own machine. No data leaves. |
-| **Your custom / remote LightRAG server** | Only if you configure a remote URL | If you opt in to a remote server, queries go to that URL. This is off by default. |
+| Destination                                                  | When                                    | Why                                                                                                                         |
+| :----------------------------------------------------------- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------- |
+| **Your AI provider** (OpenAI, Anthropic, Gemini, Groq, etc.) | Every chat message or ingestion         | To generate responses and embeddings. Only the notes you explicitly ingest or attach are sent.                              |
+| **Your local LightRAG server** (`localhost`)                 | Every query and ingestion               | The plugin talks to the LightRAG Python process running on your own machine. No data leaves.                               |
+| **Your custom / remote LightRAG server**                     | Only if you configure a remote URL      | If you opt in to a remote server, queries go to that URL. This is off by default.                                          |
 
 **If you use local models (Ollama) and a local LightRAG server, no data ever leaves your machine.**
 
@@ -111,22 +128,21 @@ Neural Composer is designed with privacy as a core principle. Here is an exact a
 
 The Obsidian automated scanner flags several capabilities. Here is the plain-English explanation for each:
 
-| Disclosure | Why it exists |
-| :--- | :--- |
-| **Direct filesystem access (`fs`)** | Required to write the LightRAG `.env` configuration file to your chosen work directory, which may be outside the vault. |
-| **Shell execution (`child_process`)** | Required to start and stop the local LightRAG Python server. The command is the exact path you configure in settings — no user input is ever interpolated into shell arguments. |
-| **Vault enumeration** | Required to list your notes for ingestion and for the RAG search index. Only metadata (file paths) is read; content is read only when you explicitly ingest a file. |
-| **Clipboard access** | Inherited from the Lexical rich-text editor used in the chat input. Allows standard paste operations. |
-| **Base64 calls (`atob`/`btoa`)** | Used by bundled dependencies: `@modelcontextprotocol/sdk` decodes JWT tokens for MCP OAuth, and `sigma`/`three-forcegraph` encode WebGL shader data. No API keys or sensitive data are encoded this way. |
+| Disclosure                              | Why it exists                                                                                                                                                                                   |
+| :-------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Direct filesystem access (`fs`)**     | Required to write the LightRAG `.env` configuration file to your chosen work directory, which may be outside the vault.                                                                         |
+| **Shell execution (`child_process`)**   | Required to start and stop the local LightRAG Python server. The command is the exact path you configure in settings — no user input is ever interpolated into shell arguments.                 |
+| **Vault enumeration**                   | Required to list your notes for ingestion and for the RAG search index. Only metadata (file paths) is read; content is read only when you explicitly ingest a file.                            |
+| **Clipboard access**                    | Inherited from the Lexical rich-text editor used in the chat input. Allows standard paste operations.                                                                                          |
+| **Base64 calls (`atob`/`btoa`)**        | Used by bundled dependencies: `@modelcontextprotocol/sdk` decodes JWT tokens for MCP OAuth, and `sigma`/`three-forcegraph` encode WebGL shader data. No API keys or sensitive data are encoded this way. |
 | **Dynamic code execution (`new Function`)** | Used by two bundled libraries: `ngraph.forcelayout` generates optimized N-dimensional physics code for the 3D graph, and `ajv` (via the MCP SDK) compiles JSON schema validators. Neither is used to execute user-provided code. |
 
 ---
 
-
-
 This project is a labor of love, built upon the shoulders of giants:
-*   Forked from the excellent **[Smart Composer](https://github.com/glowingjade/obsidian-smart-composer)** by glowingjade.
-*   Powered by the **[LightRAG](https://github.com/HKUDS/LightRAG)** library.
-*   Developed by **Oscar Campo** & **Cora** (AI).
+
+- Forked from the excellent **[Smart Composer](https://github.com/glowingjade/obsidian-smart-composer)** by glowingjade.
+- Powered by the **[LightRAG](https://github.com/HKUDS/LightRAG)** library.
+- Developed by **Oscar Campo** & **Cora** (AI).
 
 We hope this helps you connect the dots in your own second brain. Happy composing!

--- a/README.md
+++ b/README.md
@@ -1,149 +1,201 @@
 # Neural Composer
 
-**Deep, graph-based search for your Obsidian Vault.**
+**Graph-based AI chat for your Obsidian vault.**
 
 ![Hero Banner](https://raw.githubusercontent.com/oscampo/obsidian-neural-composer/main/images/hero-banner.GIF)
 
-## 👋 Hello, Obsidian Community!
-
-We built **Neural Composer** because we love Obsidian, but we often felt limited by standard search tools.
-
-Have you ever searched for a topic in your vault and gotten a list of notes that contain the _word_, but miss the _context_? Or tried to ask an AI plugin a complex question, only for it to fail because it couldn't "see" the connections between your files?
-
-**We wanted a way to talk to our notes that felt like talking to someone who actually remembers them.**
-
-That's why we integrated **LightRAG** (Graph-based Retrieval) into Obsidian. Unlike standard plugins that just look for matching text chunks, Neural Composer builds a **Knowledge Graph** of your ideas, helping you find relationships you might have forgotten.
+[![Release](https://img.shields.io/github/v/release/oscampo/obsidian-neural-composer?style=flat-square&color=6c47ff)](https://github.com/oscampo/obsidian-neural-composer/releases/latest)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Obsidian](https://img.shields.io/badge/Obsidian-Community%20Plugin-7c3aed?style=flat-square&logo=obsidian&logoColor=white)](https://obsidian.md/plugins?id=neural-composer)
 
 ---
 
-## 🤔 Why use Graph RAG?
+## TL;DR
 
-Standard AI search (Vector RAG) is great for finding _similar text_. But **Graph RAG** is better for finding _connected ideas_.
+Chat with your vault using a **Knowledge Graph**, not just keyword search. Neural Composer runs a local [LightRAG](https://github.com/HKUDS/LightRAG) server, builds a graph of your notes, and lets you ask questions that trace connections across your entire vault.
 
-| Feature             | Standard Vector Search                  | Neural Composer (Graph)                       |
-| :------------------ | :-------------------------------------- | :-------------------------------------------- |
-| **How it searches** | Finds matching keywords/concepts        | Follows relationships between entities        |
-| **Best for**        | Simple questions ("What is X?")         | Complex questions ("How does X influence Y?") |
-| **Context**         | Often fragmented                        | Holistic and interconnected                   |
+- 🔍 **Finds relationships**, not just matching words
+- ⚡ **Manages the LightRAG server** for you — no terminal juggling
+- 🔒 **100% local** when used with Ollama — your data never leaves your machine
 
----
-
-## 🛠️ How it helps (Use Cases)
-
-We designed this to fit into different workflows. Here is how it might help you:
-
-- **For Researchers:** If you have hundreds of papers, you can ask it to synthesize arguments across multiple authors, finding consensus or contradictions that a simple search would miss.
-- **For Writers & DMs:** If you are building a world or a story, the graph tracks the relationships between characters and lore, helping you maintain consistency without digging through folders.
-- **For Daily Journalers:** It connects entries from months ago to today, helping you spot patterns in your life or work that aren't obvious day-to-day.
-- **For Project Managers:** It helps visualize dependencies between different project notes that might otherwise look like separate tasks.
+**Requirements:** Python 3.10+ · `pip install "lightrag-hku[api]"` · Obsidian 1.7.2+
 
 ---
 
 ## Features
 
-We wanted the experience to be as smooth as possible:
+| | |
+|---|---|
+| **⚡ Automated Server** | Starts and stops the LightRAG Python process automatically. No terminal needed. |
+| **🧠 Graph + Vector Search** | Combines entity-relationship traversal with semantic vector search for deep, contextual answers. |
+| **📂 Vault Sync** | Set a watched folder — notes are re-indexed on save. Status dots in the file explorer show each note's graph state: 🟢 processed · 🟡 processing · 🔴 failed · 🔵 removed. |
+| **📊 Knowledge Graph View** | Explore your graph visually in 2D or 3D. Overview mode renders all nodes; Explore mode does a BFS walk from any entity. |
+| **🌐 Remote Server** | Connect to a LightRAG instance on a NAS, VPS, or Docker container. |
+| **🤖 MCP Tools** | Expose your graph to any MCP-compatible client (Claude Desktop, etc.). |
+| **🔍 Source Transparency** | Every answer includes citations `[1]` linked to the exact notes and text chunks that were used. |
+| **🔒 Local & Private** | Use Ollama for a fully offline setup, or any hosted provider you prefer. |
 
-- **⚡ Automated Server:** No need to fiddle with terminals. The plugin handles the background Python server for you (starts and stops automatically).
-- **Hybrid Search:** You don't have to choose. It combines Vector search with Graph traversal for the best results.
-- **Easy Ingestion:** Right-click any folder to add your notes to the graph. It supports PDFs, DOCX, and more... <details> <summary> Complete list of supported formats </summary> md, txt, docx, pdf, pptx, xlsx, rtf, odt, epub, html, htm, xml, json, yaml, yml, csv, tex, log, conf, ini, properties, sql, bat, sh, c, cpp, py, java, js, ts, swift, go, rb, php, css, scss, less </details>
-- **🔍 Transparency:** The chat shows you exactly which files and text segments were used to generate the answer (with citations like `[1]`), so you can always verify the source.
-- **🔒 Local & Private:** You can use local models (like Ollama) for a completely offline experience, or connect to Gemini/OpenAI if you prefer.
-- **📂 Vault Sync & Document Status** _(v1.3+)_: Set a watched folder and your notes are automatically re-indexed whenever you save them (with a 5-second debounce to avoid hammering the server). Colored dots appear directly in the file explorer next to each note: 🟢 processed, 🟡 processing or failed, 🔵 removed from graph. The watched folder itself shows an aggregate dot so you can see the overall state at a glance.
-- **🌐 Remote Server Support** _(v1.3+)_: Not running LightRAG on your main machine? Connect the plugin to a LightRAG server running on another machine — a NAS, a VPS, or a Docker container. Toggle it on in **Settings → Graph & Vault** and enter the remote URL.
-- **🔍 Knowledge Graph Visualization** _(v1.3+)_: Explore your knowledge graph visually inside Obsidian, in 2D or 3D. **Overview mode** renders all nodes in the graph. **Explore mode** starts a BFS from any entity you pick, so you can trace how ideas connect.
-- **🤖 MCP Tools** _(v1.3+)_: Expose your graph to any MCP-compatible AI client (Claude Desktop, and others) through configurable MCP servers. Ask your favorite AI client questions that are answered straight from your vault's knowledge graph.
+<details>
+<summary>Complete list of supported file formats</summary>
+
+`md` `txt` `docx` `pdf` `pptx` `xlsx` `rtf` `odt` `epub` `html` `htm` `xml` `json` `yaml` `yml` `csv` `tex` `log` `conf` `ini` `properties` `sql` `bat` `sh` `c` `cpp` `py` `java` `js` `ts` `swift` `go` `rb` `php` `css` `scss` `less`
+
+</details>
+
+---
+
+## Why Graph RAG?
+
+Standard vector search finds *similar text*. Graph RAG finds *connected ideas*.
+
+| | Standard Vector Search | Neural Composer (Graph RAG) |
+|:---|:---|:---|
+| **How it works** | Finds chunks that match your query semantically | Traverses relationships between entities in your notes |
+| **Best for** | "What is X?" | "How does X influence Y across my research?" |
+| **Context quality** | Often fragmented | Holistic — sees the whole picture |
+| **Multi-hop reasoning** | ✗ | ✓ |
 
 ---
 
 ## Getting Started
 
-> Full documentation on the [wiki](https://github.com/oscampo/obsidian-neural-composer/wiki)
+> 📖 Full documentation on the [Wiki](https://github.com/oscampo/obsidian-neural-composer/wiki)
 
-This plugin requires a small backend setup (Python) to run the LightRAG engine.
+### 1. Install the LightRAG backend
 
-### 1. One-time Setup
+```bash
+# Recommended: use a virtual environment
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install "lightrag-hku[api]"
+```
 
-1. Ensure you have **Python 3.10+** installed.
-2. Install the engine via terminal:
-   ```bash
-   pip install "lightrag-hku[api]"
-   ```
-   _(We recommend using a virtual environment)._
+Then find the path to the installed executable (you'll need it in Step 3):
+
+```bash
+which lightrag-server        # macOS / Linux
+where.exe lightrag-server    # Windows
+```
 
 ### 2. Install the Plugin
 
-- Recommended: install via **BRAT**
-- Manual Installation:
-  Download `main.js`, `manifest.json`, and `styles.css` from the **[Releases](../../releases)** page and place them in your `.obsidian/plugins/neural-composer` folder. Enable it in Obsidian.
+Search for **"Neural Composer"** in **Settings → Community Plugins → Browse** and enable it.
 
-### 3. Connect & Go
+### 3. Connect & Configure
 
-Go to **Settings → Neural Composer**. The settings panel has a sidebar with seven tabs: **Providers**, **Models**, **Chat**, **Graph & Vault**, **Tools (MCP)**, **Advanced**, and **Help**.
+Open **Settings → Neural Composer**. The panel has a sidebar with seven tabs:
 
-1. **Providers** tab: enter your API keys for whichever AI providers you use (OpenAI, Anthropic, Gemini, Ollama, etc.).
-2. **Models** tab: choose your chat model, apply model, and embedding model.
-3. **Graph & Vault** tab:
-   - Set the path to your `lightrag-server` executable.
-   - Choose a data directory where the graph will be stored.
-   - Optionally set a **watched folder** so notes are auto-synced whenever you save.
-4. Toggle **Auto-start** and click **Restart Server**.
+1. **Providers** — add your API keys (OpenAI, Anthropic, Gemini, Groq, Ollama, etc.)
+2. **Models** — select your chat, apply, and embedding models
+3. **Graph & Vault** — set the `lightrag-server` path, choose a data directory, and optionally configure a **Watched Folder** for auto-sync
+4. Toggle **Auto-start** on, then click **Restart Server**
 
-You are ready! Right-click any folder to ingest your notes and start chatting with your vault.
+A green dot in the status bar confirms the server is running. Right-click any folder in your vault to ingest notes and start chatting.
 
 ---
 
-## 🧩 Advanced Options
+<details>
+<summary>🛠️ Use Cases</summary>
 
-For those who like to tinker, we added some power features:
+- **Researchers** — synthesize arguments across hundreds of papers, surface consensus and contradictions that keyword search misses.
+- **Writers & Game Masters** — track relationships between characters and lore; keep your world internally consistent without digging through folders.
+- **Journalers** — connect entries from months ago to today, spotting patterns that aren't visible day-to-day.
+- **Project Managers** — visualize dependencies between project notes that otherwise look like separate tasks.
 
-- **Watched Folder & Status Dots:** Configure a folder to be automatically kept in sync with the graph. Colored dots in the file explorer show each note's current graph status (🟢 processed, 🟡 processing/failed, 🔵 removed) so you always know what's indexed.
-- **Remote Server Mode:** Point the plugin at a LightRAG instance running on a different machine (NAS, VPS, Docker). Useful for teams or for offloading processing to a more powerful box.
-- **Custom Ontology:** Teach the graph the specific categories of your field (e.g., "Experiment", "Theorem") instead of generic ones.
-- **Reranking:** Connect to Jina AI, Cohere, or a custom reranker endpoint for higher-precision results.
-- **MCP Tools Integration:** Expose your vault's knowledge graph to any MCP-compatible AI client. Configure MCP servers in the **Tools (MCP)** settings tab.
-- **Knowledge Graph Visualization:** Open an interactive 2D or 3D view of your graph from within Obsidian. Use Overview mode to see everything, or Explore mode to do a BFS walk from a specific entity.
+</details>
 
----
+<details>
+<summary>🧩 Advanced Options</summary>
 
-## 🔒 Privacy & Security
+| Feature | Where to configure |
+|:---|:---|
+| **Watched Folder** | Settings → Graph & Vault → Watched folder |
+| **Remote Server** | Settings → Graph & Vault → Use remote server |
+| **Custom Ontology** | Settings → Graph & Vault → Ontology section — teach the graph domain-specific entity types (e.g. "Experiment", "Theorem") |
+| **Reranking** | Settings → Graph & Vault → Reranking — Jina AI, Cohere, or a custom local endpoint |
+| **MCP Servers** | Settings → Tools (MCP) |
+| **Graph Visualization** | Settings → Graph & Vault → Graph rendering engine — 2D (fast) or 3D (immersive) |
+| **Performance Tuning** | Settings → Advanced — chunk size, overlap, async workers |
+| **Custom `.env` overrides** | Settings → Advanced — raw `.env` editor with full LightRAG configuration access |
 
-Neural Composer is designed with privacy as a core principle. Here is an exact account of every network call the plugin makes and why.
+</details>
+
+<details>
+<summary>🔒 Privacy & Security</summary>
+
+Neural Composer is designed with privacy as a core principle.
 
 ### What leaves your machine
 
-| Destination                                                  | When                               | Why                                                                                                                        |
-| :----------------------------------------------------------- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
-| **Your AI provider** (OpenAI, Anthropic, Gemini, Groq, etc.) | Every chat message or ingestion    | To generate responses and embeddings. Only the notes you explicitly ingest or attach are sent.                             |
-| **Your local LightRAG server** (`localhost`)                 | Every query and ingestion          | The plugin talks to the LightRAG Python process running on your own machine. No data leaves.                              |
-| **Your custom / remote LightRAG server**                     | Only if you configure a remote URL | If you opt in to a remote server, queries go to that URL. This is off by default.                                         |
+| Destination | When | Why |
+|:---|:---|:---|
+| **Your AI provider** (OpenAI, Anthropic, Gemini, Groq, etc.) | Every chat message or ingestion | To generate responses and embeddings. Only notes you explicitly ingest or attach are sent. |
+| **Your local LightRAG server** (`localhost`) | Every query and ingestion | The plugin talks to a Python process on your own machine. No data leaves. |
+| **Your remote LightRAG server** | Only if you configure a remote URL | Off by default. Opt-in only. |
 
-**If you use local models (Ollama) and a local LightRAG server, no data ever leaves your machine.**
+**Using Ollama + local LightRAG = zero data leaves your machine.**
 
 ### What never happens
 
-- The plugin **does not send telemetry, analytics, or crash reports** to any server.
-- The plugin **does not contact `github.com` or any other domain at runtime.** GitHub URLs visible in the settings UI are navigation links only — they are never fetched programmatically.
-- The plugin **does not store your API keys anywhere other than Obsidian's own `data.json`** in your local vault.
+- The plugin does **not** send telemetry, analytics, or crash reports.
+- The plugin does **not** contact `github.com` or any external domain at runtime. Links in the UI are navigation-only — never fetched programmatically.
+- API keys are stored **only** in Obsidian's own `data.json` in your local vault.
 
-### System-level access (Obsidian scorecard disclosures)
+### System-level access disclosures
 
-The Obsidian automated scanner flags several capabilities. Here is the plain-English explanation for each:
+<details>
+<summary>Why the Obsidian scanner flags certain capabilities</summary>
 
-| Disclosure                                  | Why it exists                                                                                                                                                                                         |
-| :------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Direct filesystem access (`fs`)**         | Required to write the LightRAG `.env` configuration file to your chosen work directory, which may be outside the vault.                                                                               |
-| **Shell execution (`child_process`)**       | Required to start and stop the local LightRAG Python server. The command is the exact path you configure in settings — no user input is ever interpolated into shell arguments.                       |
-| **Vault enumeration**                       | Required to list your notes for ingestion and for the RAG search index. Only metadata (file paths) is read; content is read only when you explicitly ingest a file.                                   |
-| **Clipboard access**                        | Inherited from the Lexical rich-text editor used in the chat input. Allows standard paste operations.                                                                                                |
-| **Base64 calls (`atob`/`btoa`)**            | Used by bundled dependencies: `@modelcontextprotocol/sdk` decodes JWT tokens for MCP OAuth, and `sigma`/`three-forcegraph` encode WebGL shader data. No API keys or sensitive data are encoded this way. |
-| **Dynamic code execution (`new Function`)** | Used by two bundled libraries: `ngraph.forcelayout` generates optimized N-dimensional physics code for the 3D graph, and `ajv` (via the MCP SDK) compiles JSON schema validators. Neither is used to execute user-provided code. |
+| Capability | Reason |
+|:---|:---|
+| **`fs` (filesystem)** | Writes the LightRAG `.env` config file to your chosen work directory, which may be outside the vault. |
+| **`child_process` (shell)** | Starts and stops the local LightRAG Python server. The command is always the exact path you configure — no user input is interpolated into shell arguments. |
+| **Vault enumeration** | Lists file paths for ingestion and the search index. File content is only read when you explicitly ingest a file. |
+| **Clipboard** | Inherited from the Lexical rich-text editor in the chat input. Standard paste operations only. |
+| **`atob`/`btoa` (Base64)** | Used by bundled deps: `@modelcontextprotocol/sdk` decodes JWT tokens for MCP OAuth; `sigma`/`three-forcegraph` encode WebGL shader data. No sensitive data is encoded this way. |
+| **`new Function`** | Used by two bundled libraries: `ngraph.forcelayout` (3D physics) and `ajv` (JSON schema validation via MCP SDK). Neither executes user-provided code. |
+
+</details>
+</details>
+
+<details>
+<summary>📋 Changelog</summary>
+
+### v1.3.1 — 2026-05-25
+- Fix: removed all `!important` CSS declarations — replaced with higher-specificity selectors to comply with the Obsidian plugin linter.
+
+### v1.3.0 — 2026-05-24
+- **Settings UI redesign** — new sidebar navigation with 7 tabs: Providers, Models, Chat, Graph & Vault, Tools (MCP), Advanced, Help.
+- **Document status tracking** — colored dots in the file explorer for each note (🟢 processed, 🟡 processing, 🔴 failed, 🔵 removed). Watched folder shows an aggregate status dot.
+- **LightRAG version detection** — the server version is displayed as a badge in Settings → Graph & Vault.
+- **Watched folder sync** — notes are automatically re-indexed on save with a 5-second debounce.
+- **"Remove from graph" action** — right-click context menu lets you remove individual notes from the graph without deleting the file.
+- **Tooltip improvements** — status bar tooltip correctly distinguishes local vs. remote server offline state.
+
+### v1.2.3 — 2026-05-22
+- Fix: correct LightRAG provider config for OpenRouter and Ollama (LLM\_BINDING\_HOST was missing, causing 401 errors).
+- Fix: expose active embedding model selector in settings UI.
+- Add: "Reprocess failed documents" button in Graph & Vault settings.
+- Fix: stop server now correctly kills orphaned processes on macOS/Linux via port lookup.
+
+### v1.2.1 — 2026-05-20
+- **Knowledge Graph Visualization** — 2D and 3D interactive graph view inside Obsidian.
+- Overview mode (all nodes) and Explore mode (BFS from a selected entity).
+- Real relevance scores for cited references (citation-frequency formula).
+- Improved "Context used" panel — shows scores, snippets, and click-to-open for `.md` files.
+- Fix: single-click on isolated nodes now auto-explores and shows full entity details.
+
+### v1.2.0 — 2026-05-17
+- Initial public release on the Obsidian Community Plugin marketplace.
+- Local LightRAG server management (auto-start, restart, stop).
+- Right-click folder ingestion with multi-format support.
+- Chat with graph RAG, hybrid query modes, Jina/Cohere reranking.
+- Custom ontology (entity types) and `.env` editor.
+
+</details>
 
 ---
 
-This project is a labor of love, built upon the shoulders of giants:
-
-- Forked from the excellent **[Smart Composer](https://github.com/glowingjade/obsidian-smart-composer)** by glowingjade.
-- Powered by the **[LightRAG](https://github.com/HKUDS/LightRAG)** library.
-- Developed by **Oscar Campo** & **Cora** (AI).
-
-We hope this helps you connect the dots in your own second brain. Happy composing!
+Built on the shoulders of giants:
+- Forked from **[Smart Composer](https://github.com/glowingjade/obsidian-smart-composer)** by glowingjade
+- Powered by **[LightRAG](https://github.com/HKUDS/LightRAG)**
+- Developed by **Oscar Campo** & **Cora** (AI)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Neural Composer
+
 **Deep, graph-based search for your Obsidian Vault.**
 
 ![Hero Banner](https://raw.githubusercontent.com/oscampo/obsidian-neural-composer/main/images/hero-banner.GIF)
@@ -19,11 +20,11 @@ That's why we integrated **LightRAG** (Graph-based Retrieval) into Obsidian. Unl
 
 Standard AI search (Vector RAG) is great for finding _similar text_. But **Graph RAG** is better for finding _connected ideas_.
 
-| Feature            | Standard Vector Search                  | Neural Composer (Graph)                      |
-| :----------------- | :-------------------------------------- | :------------------------------------------- |
-| **How it searches** | Finds matching keywords/concepts        | Follows relationships between entities       |
+| Feature             | Standard Vector Search                  | Neural Composer (Graph)                       |
+| :------------------ | :-------------------------------------- | :-------------------------------------------- |
+| **How it searches** | Finds matching keywords/concepts        | Follows relationships between entities        |
 | **Best for**        | Simple questions ("What is X?")         | Complex questions ("How does X influence Y?") |
-| **Context**         | Often fragmented                        | Holistic and interconnected                  |
+| **Context**         | Often fragmented                        | Holistic and interconnected                   |
 
 ---
 
@@ -77,7 +78,7 @@ This plugin requires a small backend setup (Python) to run the LightRAG engine.
 
 ### 3. Connect & Go
 
-Go to **Settings → Neural Composer**. The settings panel has a sidebar with seven tabs.
+Go to **Settings → Neural Composer**. The settings panel has a sidebar with seven tabs: **Providers**, **Models**, **Chat**, **Graph & Vault**, **Tools (MCP)**, **Advanced**, and **Help**.
 
 1. **Providers** tab: enter your API keys for whichever AI providers you use (OpenAI, Anthropic, Gemini, Ollama, etc.).
 2. **Models** tab: choose your chat model, apply model, and embedding model.
@@ -110,11 +111,11 @@ Neural Composer is designed with privacy as a core principle. Here is an exact a
 
 ### What leaves your machine
 
-| Destination                                                  | When                                    | Why                                                                                                                         |
-| :----------------------------------------------------------- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------- |
-| **Your AI provider** (OpenAI, Anthropic, Gemini, Groq, etc.) | Every chat message or ingestion         | To generate responses and embeddings. Only the notes you explicitly ingest or attach are sent.                              |
-| **Your local LightRAG server** (`localhost`)                 | Every query and ingestion               | The plugin talks to the LightRAG Python process running on your own machine. No data leaves.                               |
-| **Your custom / remote LightRAG server**                     | Only if you configure a remote URL      | If you opt in to a remote server, queries go to that URL. This is off by default.                                          |
+| Destination                                                  | When                               | Why                                                                                                                        |
+| :----------------------------------------------------------- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| **Your AI provider** (OpenAI, Anthropic, Gemini, Groq, etc.) | Every chat message or ingestion    | To generate responses and embeddings. Only the notes you explicitly ingest or attach are sent.                             |
+| **Your local LightRAG server** (`localhost`)                 | Every query and ingestion          | The plugin talks to the LightRAG Python process running on your own machine. No data leaves.                              |
+| **Your custom / remote LightRAG server**                     | Only if you configure a remote URL | If you opt in to a remote server, queries go to that URL. This is off by default.                                         |
 
 **If you use local models (Ollama) and a local LightRAG server, no data ever leaves your machine.**
 
@@ -128,13 +129,13 @@ Neural Composer is designed with privacy as a core principle. Here is an exact a
 
 The Obsidian automated scanner flags several capabilities. Here is the plain-English explanation for each:
 
-| Disclosure                              | Why it exists                                                                                                                                                                                   |
-| :-------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Direct filesystem access (`fs`)**     | Required to write the LightRAG `.env` configuration file to your chosen work directory, which may be outside the vault.                                                                         |
-| **Shell execution (`child_process`)**   | Required to start and stop the local LightRAG Python server. The command is the exact path you configure in settings — no user input is ever interpolated into shell arguments.                 |
-| **Vault enumeration**                   | Required to list your notes for ingestion and for the RAG search index. Only metadata (file paths) is read; content is read only when you explicitly ingest a file.                            |
-| **Clipboard access**                    | Inherited from the Lexical rich-text editor used in the chat input. Allows standard paste operations.                                                                                          |
-| **Base64 calls (`atob`/`btoa`)**        | Used by bundled dependencies: `@modelcontextprotocol/sdk` decodes JWT tokens for MCP OAuth, and `sigma`/`three-forcegraph` encode WebGL shader data. No API keys or sensitive data are encoded this way. |
+| Disclosure                                  | Why it exists                                                                                                                                                                                         |
+| :------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Direct filesystem access (`fs`)**         | Required to write the LightRAG `.env` configuration file to your chosen work directory, which may be outside the vault.                                                                               |
+| **Shell execution (`child_process`)**       | Required to start and stop the local LightRAG Python server. The command is the exact path you configure in settings — no user input is ever interpolated into shell arguments.                       |
+| **Vault enumeration**                       | Required to list your notes for ingestion and for the RAG search index. Only metadata (file paths) is read; content is read only when you explicitly ingest a file.                                   |
+| **Clipboard access**                        | Inherited from the Lexical rich-text editor used in the chat input. Allows standard paste operations.                                                                                                |
+| **Base64 calls (`atob`/`btoa`)**            | Used by bundled dependencies: `@modelcontextprotocol/sdk` decodes JWT tokens for MCP OAuth, and `sigma`/`three-forcegraph` encode WebGL shader data. No API keys or sensitive data are encoded this way. |
 | **Dynamic code execution (`new Function`)** | Used by two bundled libraries: `ngraph.forcelayout` generates optimized N-dimensional physics code for the 3D graph, and `ajv` (via the MCP SDK) compiles JSON schema validators. Neither is used to execute user-provided code. |
 
 ---

--- a/src/core/llm/gemini.ts
+++ b/src/core/llm/gemini.ts
@@ -85,15 +85,27 @@ export class GeminiProvider extends BaseLLMProvider<
         : undefined
 
     try {
+      // Gemini 2.5+ thinking models require a `thought_signature` field on every
+      // FunctionCallPart when tools are in use. The current SDK (@google/generative-ai
+      // v0.24.x) does not propagate thought_signature, so tool calls always fail with
+      // a 400 error on these models. Setting thinkingBudget=0 disables thinking mode
+      // for this request, which removes the thought_signature requirement and lets tool
+      // calls succeed. TODO: migrate to @google/genai SDK (v2+) which has full
+      // thought_signature support, so thinking can remain enabled alongside tools.
+      const hasTools = (request.tools?.length ?? 0) > 0
+      const generationConfig = {
+        maxOutputTokens: request.max_tokens,
+        temperature: request.temperature,
+        topP: request.top_p,
+        presencePenalty: request.presence_penalty,
+        frequencyPenalty: request.frequency_penalty,
+        ...(hasTools ? { thinkingConfig: { thinkingBudget: 0 } } : {}),
+      } as Record<string, unknown>
+
       const model = this.client.getGenerativeModel({
         model: request.model,
-        generationConfig: {
-          maxOutputTokens: request.max_tokens,
-          temperature: request.temperature,
-          topP: request.top_p,
-          presencePenalty: request.presence_penalty,
-          frequencyPenalty: request.frequency_penalty,
-        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        generationConfig: generationConfig as any,
         systemInstruction: systemInstruction,
       })
 
@@ -156,15 +168,21 @@ export class GeminiProvider extends BaseLLMProvider<
         : undefined
 
     try {
+      // Same thinkingBudget=0 workaround as in generateResponse — see comment there.
+      const hasTools = (request.tools?.length ?? 0) > 0
+      const generationConfig = {
+        maxOutputTokens: request.max_tokens,
+        temperature: request.temperature,
+        topP: request.top_p,
+        presencePenalty: request.presence_penalty,
+        frequencyPenalty: request.frequency_penalty,
+        ...(hasTools ? { thinkingConfig: { thinkingBudget: 0 } } : {}),
+      } as Record<string, unknown>
+
       const model = this.client.getGenerativeModel({
         model: request.model,
-        generationConfig: {
-          maxOutputTokens: request.max_tokens,
-          temperature: request.temperature,
-          topP: request.top_p,
-          presencePenalty: request.presence_penalty,
-          frequencyPenalty: request.frequency_penalty,
-        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        generationConfig: generationConfig as any,
         systemInstruction: systemInstruction,
       })
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -10,19 +10,19 @@ This is where you tell the plugin which AI providers you have access to and ente
 
 **Supported providers:**
 
-| Provider        | Type   | Notes                                              |
-| :-------------- | :----- | :------------------------------------------------- |
-| OpenAI          | Cloud  | GPT-4o, GPT-4.1, o3, etc.                        |
-| Anthropic       | Cloud  | Claude 3.x / 4.x models                          |
-| Gemini          | Cloud  | Google's Gemini family                            |
-| Groq            | Cloud  | Fast inference, Llama/Mixtral models              |
-| Deepseek        | Cloud  | Deepseek-chat and Deepseek-reasoner               |
-| Mistral         | Cloud  | Mistral and Mixtral models                        |
-| Perplexity      | Cloud  | Search-augmented models                           |
-| OpenRouter      | Cloud  | Unified gateway to many providers                 |
-| Ollama          | Local  | Fully offline; no API key required                |
-| LM Studio       | Local  | Local model runner with an OpenAI-compatible API  |
-| Morph           | Cloud  | Code-focused model for the Apply step             |
+| Provider    | Type  | Notes                                             |
+| :---------- | :---- | :------------------------------------------------ |
+| OpenAI      | Cloud | GPT-4o, GPT-4.1, o3, etc.                       |
+| Anthropic   | Cloud | Claude 3.x / 4.x models                         |
+| Gemini      | Cloud | Google's Gemini family                           |
+| Groq        | Cloud | Fast inference, Llama/Mixtral models             |
+| Deepseek    | Cloud | Deepseek-chat and Deepseek-reasoner              |
+| Mistral     | Cloud | Mistral and Mixtral models                       |
+| Perplexity  | Cloud | Search-augmented models                          |
+| OpenRouter  | Cloud | Unified gateway to many providers                |
+| Ollama      | Local | Fully offline; no API key required               |
+| LM Studio   | Local | Local model runner with an OpenAI-compatible API |
+| Morph       | Cloud | Code-focused model for the Apply step            |
 
 For each cloud provider, paste the API key into the corresponding field. Keys are stored only in Obsidian's local `data.json` and never sent anywhere except the provider's own API.
 
@@ -34,11 +34,11 @@ For Ollama and LM Studio, enter the base URL of their local API server (defaults
 
 Three model slots to configure:
 
-| Slot                | Purpose                                                                                   |
-| :------------------ | :---------------------------------------------------------------------------------------- |
-| **Chat model**      | Answers your questions in the chat pane. Pick whatever gives you the best quality/cost.   |
-| **Apply model**     | Used when applying a suggested edit back into your note. A fast, cheap model works well.  |
-| **Embedding model** | Converts text to vectors for similarity search. Must match what LightRAG expects.         |
+| Slot                | Purpose                                                                                 |
+| :------------------ | :-------------------------------------------------------------------------------------- |
+| **Chat model**      | Answers your questions in the chat pane. Pick whatever gives you the best quality/cost. |
+| **Apply model**     | Used when applying a suggested edit back into your note. A fast, cheap model works well. |
+| **Embedding model** | Converts text to vectors for similarity search. Must match what LightRAG expects.       |
 
 After changing the embedding model, you should re-ingest your notes so the stored embeddings stay consistent.
 
@@ -100,11 +100,11 @@ Add arbitrary `KEY=VALUE` pairs that are injected into the LightRAG server's env
 
 ### Performance tuning
 
-| Setting          | What it does                                                                                       |
-| :--------------- | :------------------------------------------------------------------------------------------------- |
-| **Chunk size**   | How many characters each text chunk contains before being embedded. Larger = more context per chunk, but more tokens per embedding call. |
-| **Chunk overlap** | How many characters overlap between consecutive chunks. Helps avoid splitting concepts across chunk boundaries. |
-| **Async workers** | Number of parallel workers LightRAG uses during ingestion. Higher = faster ingestion, higher API concurrency. |
+| Setting           | What it does                                                                                                                                   |
+| :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chunk size**    | How many characters each text chunk contains before being embedded. Larger = more context per chunk, but more tokens per embedding call.       |
+| **Chunk overlap** | How many characters overlap between consecutive chunks. Helps avoid splitting concepts across chunk boundaries.                                |
+| **Async workers** | Number of parallel workers LightRAG uses during ingestion. Higher = faster ingestion, higher API concurrency.                                  |
 
 ---
 
@@ -124,7 +124,7 @@ Each MCP server entry has:
 
 ### Claude Desktop example
 
-To expose your graph to Claude Desktop, add an entry with transport `stdio` and point the command at the Neural Composer MCP bridge. Then add the corresponding entry in Claude Desktop's `claude_desktop_config.json`. The wiki [Features](Features) page has more detail.
+To expose your graph to Claude Desktop, add an entry with transport `stdio` and point the command at the Neural Composer MCP bridge. Then add the corresponding entry in Claude Desktop's `claude_desktop_config.json`. The [Features](Features) page has more detail.
 
 ---
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,12 +1,16 @@
 # Configuration
 
-The settings panel (**Settings → Neural Composer**) has a sidebar with seven tabs. This page explains each one.
+The settings panel (**Settings → Neural Composer**) has a sidebar with seven tabs. This page explains every option in each tab.
+
+[screenshot: full settings panel — sidebar showing the 7 tabs: Providers, Models, Chat, Graph & Vault, Tools (MCP), Advanced, Help]
 
 ---
 
 ## Providers
 
-This is where you tell the plugin which AI providers you have access to and enter the corresponding API keys.
+This tab manages which AI providers the plugin can use and stores your API credentials.
+
+[screenshot: Providers tab — showing a list of provider rows, each with a name and masked API key field]
 
 **Supported providers:**
 
@@ -24,9 +28,9 @@ This is where you tell the plugin which AI providers you have access to and ente
 | LM Studio   | Local | Local model runner with an OpenAI-compatible API |
 | Morph       | Cloud | Code-focused model for the Apply step            |
 
-For each cloud provider, paste the API key into the corresponding field. Keys are stored only in Obsidian's local `data.json` and never sent anywhere except the provider's own API.
+For each cloud provider, paste the API key into the corresponding field. Keys are stored only in Obsidian's local `data.json` and are never sent anywhere except the provider's own API endpoint.
 
-For Ollama and LM Studio, enter the base URL of their local API server (defaults are `http://localhost:11434` and `http://localhost:1234` respectively). No API key is needed.
+For Ollama and LM Studio, enter the base URL of their local API server (defaults: `http://localhost:11434` and `http://localhost:1234`). No API key is needed.
 
 ---
 
@@ -34,57 +38,119 @@ For Ollama and LM Studio, enter the base URL of their local API server (defaults
 
 Three model slots to configure:
 
+[screenshot: Models tab — three dropdowns: Chat model, Apply model, Embedding model]
+
 | Slot                | Purpose                                                                                 |
 | :------------------ | :-------------------------------------------------------------------------------------- |
-| **Chat model**      | Answers your questions in the chat pane. Pick whatever gives you the best quality/cost. |
-| **Apply model**     | Used when applying a suggested edit back into your note. A fast, cheap model works well. |
-| **Embedding model** | Converts text to vectors for similarity search. Must match what LightRAG expects.       |
+| **Chat model**      | Answers your questions in the chat pane. Choose for quality and cost. |
+| **Apply model**     | Applies a suggested edit back into your note. A fast, cheap model works well here. |
+| **Embedding model** | Converts text to vectors for similarity search. Must match the model LightRAG was indexed with. |
 
-After changing the embedding model, you should re-ingest your notes so the stored embeddings stay consistent.
+> **Important:** After changing the embedding model, re-ingest your notes so the stored embeddings stay consistent with the new model.
+
+---
+
+## Chat
+
+Controls the behavior of the chat pane.
+
+[screenshot: Chat tab — showing the three toggles/fields described below]
+
+| Setting | Default | What it does |
+| :--- | :--- | :--- |
+| **Include current file content** | On | Automatically attaches the content of the note you have open in the editor to every message. Useful when asking questions about the file you're working on. |
+| **Enable tools** | On | Allows the AI to use MCP tools and built-in vault tools (e.g., reading or editing notes). Disable if you want pure chat with no side-effects. |
+| **Max auto-iterations** | 1 | How many times the model can automatically call a tool and loop back before stopping and showing you the result. Increase for complex tool-use workflows; lower to 1 for predictable output. |
+
+**System prompt**
+
+A free-text field appended to every chat request before the user message. Use this to give the model standing instructions — e.g., *"Always answer in Spanish"* or *"You are my research assistant. Be concise."*
 
 ---
 
 ## Graph & Vault
 
-This tab controls the LightRAG backend and vault integration.
+Controls the LightRAG backend, vault integration, and ingestion behavior. This is the most important tab for initial setup.
 
-### Local vs remote server
+[screenshot: Graph & Vault tab — full view showing all sections]
 
-By default the plugin runs `lightrag-server` as a subprocess on your machine. If you toggle **Use remote server**, a URL field appears. Enter the base URL of your remote LightRAG instance (e.g., `http://192.168.1.50:9621`). The plugin will send all graph queries and ingestion requests to that URL instead of spawning a local process.
+### Local vs. remote server
+
+By default the plugin runs `lightrag-server` as a subprocess on your machine (**local mode**). Toggle **Use remote server** to connect to a LightRAG instance running elsewhere — on a NAS, VPS, or Docker container. When remote mode is on, a URL field appears.
+
+[screenshot: detail of the "Use remote server" toggle and the URL input field that appears when it's enabled]
 
 ### Command path
 
-The absolute path to the `lightrag-server` binary. See [Installation](Installation) for how to find this. This field is only relevant when using a local server.
+The absolute path to the `lightrag-server` binary. Required for local mode only. See [Installation](Installation) Step 2 for how to find this path.
 
 ### Data directory
 
-The folder where LightRAG stores the graph database, vector index, and cache files. This can be anywhere on your disk — it does not need to be inside your vault. Use a dedicated folder and don't put other files in it.
+The folder where LightRAG stores the graph database, vector index, and cache files. Can be anywhere on your disk — it does not need to be inside the vault. Use a dedicated, empty folder. Do not put other files in it.
 
-### Watched folder
+### Auto-start
 
-When set, Neural Composer watches this vault folder for file changes. Every time you save a note inside it, the plugin queues it for re-ingestion (with a 5-second debounce). Renames and deletes are also handled: a renamed note is re-ingested under its new name, and a deleted note is removed from the graph.
-
-Leave this blank if you prefer to ingest manually via right-click.
+When on, the plugin starts `lightrag-server` automatically when Obsidian opens, and stops it when Obsidian closes. Recommended for most users.
 
 ### Graph logic model
 
-The LLM used by LightRAG internally to extract entities and relationships during ingestion. This is separate from your chat model. A cost-efficient model (e.g., `gemini-flash` or `gpt-4o-mini`) is usually fine here.
+The LLM used by LightRAG internally to extract entities and relationships during ingestion. This is separate from your chat model. A cost-efficient model (e.g., `gemini-flash` or `gpt-4o-mini`) is usually sufficient.
 
 ### Embedding model (server-side)
 
-The embedding model LightRAG uses on the server side. Must be consistent with what was used when the graph was first built. Changing this and re-ingesting will rebuild the vector index.
+The embedding model LightRAG uses on the server side. Must be consistent with the model used when the graph was first built. Changing this and re-ingesting will rebuild the vector index from scratch.
 
 ### Summary language
 
 The language LightRAG uses when writing entity summaries into the graph. Defaults to English. Change this if your notes are primarily in another language.
 
-### Citations toggle
+### Citations
 
-When enabled, chat responses include numbered citation markers (e.g., `[1]`) linked to the source documents and text chunks that were retrieved. Disable if you find citations cluttering the output.
+When enabled, chat responses include numbered citation markers (e.g., `[1]`) linked to the source documents and text chunks that were retrieved. Disable if you prefer cleaner output.
 
-### Auto-start
+### Query mode
 
-When on, the plugin starts `lightrag-server` automatically when Obsidian opens, and stops it when Obsidian closes. Recommended for most users.
+Controls the retrieval strategy used for each chat query. You can also change this per-query from the dropdown in the chat toolbar.
+
+[screenshot: query mode dropdown in the chat toolbar showing the six options]
+
+| Mode       | Best for                                                                 |
+| :--------- | :----------------------------------------------------------------------- |
+| **local**  | Precise factual questions — fast vector similarity search               |
+| **global** | Broad, synthesizing questions — traverses entity relationships           |
+| **hybrid** | A good default — combines local and global                               |
+| **naive**  | Comparing output with and without graph traversal                        |
+| **mix**    | Richest answers — weighted blend of all strategies; uses more tokens     |
+| **bypass** | Questions unrelated to your vault — skips retrieval, goes straight to LLM |
+
+### Watched folder
+
+When set, Neural Composer watches this vault folder for file changes. Every time you save a note inside it, the plugin queues it for re-ingestion (with a 5-second debounce). Renames and deletes are handled automatically.
+
+Leave this blank if you prefer to ingest manually via right-click → **Add to graph**.
+
+### Reranking
+
+Reranking runs a second-pass scoring model over retrieved chunks to improve result quality before the LLM sees them. Optional, but useful when dealing with very large graphs.
+
+[screenshot: Reranking section — showing the provider dropdown (None / Jina AI / Cohere / Custom) and the fields that appear below it]
+
+| Setting | Notes |
+| :--- | :--- |
+| **Provider** | None (off), Jina AI, Cohere, or Custom (local endpoint) |
+| **Model** | The reranker model name. Jina default: `jina-reranker-v2-base-multilingual`. Cohere default: `rerank-english-v3.0`. |
+| **API key** | Required for Jina AI and Cohere. Not needed for a custom local endpoint. |
+| **Host** | Only shown for Custom — the base URL of your local reranking server. |
+
+### Ontology (entity types)
+
+Lets you teach the graph your domain's vocabulary so LightRAG extracts the right kinds of entities from your notes.
+
+[screenshot: Ontology section — showing the toggle "Use custom entity types" and the textarea below it with example types]
+
+Toggle **Use custom entity types** to enable. Then enter a comma-separated list of entity type names in the textarea (e.g., `Person, Experiment, Theorem, Location`). LightRAG will prioritize these types when building the graph.
+
+> **LightRAG v1.5+ note:** Version 1.5 replaced the inline entity types list with a jinja2 template file. When Neural Composer detects a v1.5+ server, the textarea is replaced with a **file path** field — point it at a `.jinja2` template file in your data directory. A migration banner will appear in settings explaining the change.
 
 ---
 
@@ -92,19 +158,20 @@ When on, the plugin starts `lightrag-server` automatically when Obsidian opens, 
 
 ### .env editor
 
-LightRAG is configured via a `.env` file in its data directory. The Advanced tab includes a text editor for this file so you can set options that the UI doesn't expose directly (e.g., `LIGHTRAG_KV_STORAGE`, `LIGHTRAG_GRAPH_STORAGE`).
+LightRAG is configured via a `.env` file in its data directory. The Advanced tab includes a raw text editor for this file, letting you set options that the UI doesn't expose — for example, `LIGHTRAG_KV_STORAGE`, `LIGHTRAG_GRAPH_STORAGE`, or provider-specific environment variables.
 
-### Custom environment variables
+[screenshot: Advanced tab — .env editor textarea with a few KEY=VALUE lines visible]
 
-Add arbitrary `KEY=VALUE` pairs that are injected into the LightRAG server's environment on startup. Useful for proxy settings or provider-specific options.
+Changes to the `.env` file take effect after the next **Restart Server**.
 
 ### Performance tuning
 
-| Setting           | What it does                                                                                                                                   |
-| :---------------- | :--------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Chunk size**    | How many characters each text chunk contains before being embedded. Larger = more context per chunk, but more tokens per embedding call.       |
-| **Chunk overlap** | How many characters overlap between consecutive chunks. Helps avoid splitting concepts across chunk boundaries.                                |
-| **Async workers** | Number of parallel workers LightRAG uses during ingestion. Higher = faster ingestion, higher API concurrency.                                  |
+| Setting                 | Default | What it does                                                                                   |
+| :---------------------- | :------ | :--------------------------------------------------------------------------------------------- |
+| **Chunk size**          | 1200    | Characters per text chunk before embedding. Larger = more context per chunk, more tokens per call. |
+| **Chunk overlap**       | 100     | Characters shared between consecutive chunks. Prevents concepts from being split at boundaries. |
+| **Async workers**       | 4       | Parallel workers during ingestion. Higher = faster ingestion, higher API concurrency and cost. |
+| **Max parallel insert** | 1       | Parallel document inserts. Increase carefully — too high can overwhelm the LightRAG pipeline.  |
 
 ---
 
@@ -112,22 +179,34 @@ Add arbitrary `KEY=VALUE` pairs that are injected into the LightRAG server's env
 
 Neural Composer can expose your vault's knowledge graph to external AI clients via the [Model Context Protocol](https://modelcontextprotocol.io/).
 
+[screenshot: Tools (MCP) tab — showing an empty server list with an "Add MCP server" button]
+
 ### Adding an MCP server
 
-Each MCP server entry has:
+Each entry has:
 
-- **Name** — A label for your own reference.
-- **Transport** — `stdio` or `sse`. Use `stdio` for local clients (Claude Desktop); use `sse` for network-accessible servers.
-- **Command / URL** — For `stdio`: the command to launch the MCP client bridge. For `sse`: the URL of the SSE endpoint.
-- **Arguments** — Additional arguments passed to the command (stdio only).
-- **Environment** — Key/value pairs injected when the command is started (stdio only).
+| Field | Notes |
+| :--- | :--- |
+| **Name** | A label for your own reference. |
+| **Transport** | `stdio` (local clients) or `sse` (network). Use `stdio` for Claude Desktop. |
+| **Command / URL** | For `stdio`: the command to launch the MCP client bridge. For `sse`: the SSE endpoint URL. |
+| **Arguments** | Extra arguments passed to the command (`stdio` only). |
+| **Environment** | Key/value pairs injected into the command's environment (`stdio` only). |
 
 ### Claude Desktop example
 
-To expose your graph to Claude Desktop, add an entry with transport `stdio` and point the command at the Neural Composer MCP bridge. Then add the corresponding entry in Claude Desktop's `claude_desktop_config.json`. The [Features](Features) page has more detail.
+1. In the Tools (MCP) tab, add a new server with transport `stdio`.
+2. Set the command to the Neural Composer MCP bridge path.
+3. Add the corresponding entry to Claude Desktop's `claude_desktop_config.json`.
+
+[screenshot: filled-in MCP server form with example values for Claude Desktop]
+
+See the [Features](Features) page for a full walkthrough of the MCP integration.
 
 ---
 
 ## Help
 
-The Help tab contains quick-start guidance, links to this wiki, and the plugin version. Nothing to configure here — it's a reference panel you can open without leaving Obsidian.
+The Help tab contains quick-start guidance, links to this wiki, and the current plugin and server version. Nothing to configure here — it's a reference panel you can consult without leaving Obsidian.
+
+[screenshot: Help tab showing version badge, quick-start steps, and wiki link]

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -177,31 +177,36 @@ Changes to the `.env` file take effect after the next **Restart Server**.
 
 ## Tools (MCP)
 
-Neural Composer can expose your vault's knowledge graph to external AI clients via the [Model Context Protocol](https://modelcontextprotocol.io/).
+Neural Composer connects to external [Model Context Protocol](https://modelcontextprotocol.io/) servers and makes their tools available inside the chat pane. This tab is where you register those servers.
+
+> Neural Composer is an MCP **client** — it calls tools *from* external servers. It does not expose itself as a server to other applications.
 
 [screenshot: Tools (MCP) tab — showing an empty server list with an "Add MCP server" button]
 
 ### Adding an MCP server
 
-Each entry has:
+Click **Add MCP server** and fill in:
 
 | Field | Notes |
 | :--- | :--- |
-| **Name** | A label for your own reference. |
-| **Transport** | `stdio` (local clients) or `sse` (network). Use `stdio` for Claude Desktop. |
-| **Command / URL** | For `stdio`: the command to launch the MCP client bridge. For `sse`: the SSE endpoint URL. |
-| **Arguments** | Extra arguments passed to the command (`stdio` only). |
-| **Environment** | Key/value pairs injected into the command's environment (`stdio` only). |
+| **Name** | A label for your own reference (e.g., `GitHub`). |
+| **Parameters** | A JSON object with `command`, optional `args`, and optional `env`. See below. |
 
-### Claude Desktop example
+### Parameters format
 
-1. In the Tools (MCP) tab, add a new server with transport `stdio`.
-2. Set the command to the Neural Composer MCP bridge path.
-3. Add the corresponding entry to Claude Desktop's `claude_desktop_config.json`.
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..."
+  }
+}
+```
 
-[screenshot: filled-in MCP server form with example values for Claude Desktop]
+Paste only this inner object — do not wrap it in a `mcpServers` key.
 
-See the [Features](Features) page for a full walkthrough of the MCP integration.
+See the [MCP Tools](MCP-Tools) page for full examples and troubleshooting.
 
 ---
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,0 +1,133 @@
+# Configuration
+
+The settings panel (**Settings → Neural Composer**) has a sidebar with seven tabs. This page explains each one.
+
+---
+
+## Providers
+
+This is where you tell the plugin which AI providers you have access to and enter the corresponding API keys.
+
+**Supported providers:**
+
+| Provider        | Type   | Notes                                              |
+| :-------------- | :----- | :------------------------------------------------- |
+| OpenAI          | Cloud  | GPT-4o, GPT-4.1, o3, etc.                        |
+| Anthropic       | Cloud  | Claude 3.x / 4.x models                          |
+| Gemini          | Cloud  | Google's Gemini family                            |
+| Groq            | Cloud  | Fast inference, Llama/Mixtral models              |
+| Deepseek        | Cloud  | Deepseek-chat and Deepseek-reasoner               |
+| Mistral         | Cloud  | Mistral and Mixtral models                        |
+| Perplexity      | Cloud  | Search-augmented models                           |
+| OpenRouter      | Cloud  | Unified gateway to many providers                 |
+| Ollama          | Local  | Fully offline; no API key required                |
+| LM Studio       | Local  | Local model runner with an OpenAI-compatible API  |
+| Morph           | Cloud  | Code-focused model for the Apply step             |
+
+For each cloud provider, paste the API key into the corresponding field. Keys are stored only in Obsidian's local `data.json` and never sent anywhere except the provider's own API.
+
+For Ollama and LM Studio, enter the base URL of their local API server (defaults are `http://localhost:11434` and `http://localhost:1234` respectively). No API key is needed.
+
+---
+
+## Models
+
+Three model slots to configure:
+
+| Slot                | Purpose                                                                                   |
+| :------------------ | :---------------------------------------------------------------------------------------- |
+| **Chat model**      | Answers your questions in the chat pane. Pick whatever gives you the best quality/cost.   |
+| **Apply model**     | Used when applying a suggested edit back into your note. A fast, cheap model works well.  |
+| **Embedding model** | Converts text to vectors for similarity search. Must match what LightRAG expects.         |
+
+After changing the embedding model, you should re-ingest your notes so the stored embeddings stay consistent.
+
+---
+
+## Graph & Vault
+
+This tab controls the LightRAG backend and vault integration.
+
+### Local vs remote server
+
+By default the plugin runs `lightrag-server` as a subprocess on your machine. If you toggle **Use remote server**, a URL field appears. Enter the base URL of your remote LightRAG instance (e.g., `http://192.168.1.50:9621`). The plugin will send all graph queries and ingestion requests to that URL instead of spawning a local process.
+
+### Command path
+
+The absolute path to the `lightrag-server` binary. See [Installation](Installation) for how to find this. This field is only relevant when using a local server.
+
+### Data directory
+
+The folder where LightRAG stores the graph database, vector index, and cache files. This can be anywhere on your disk — it does not need to be inside your vault. Use a dedicated folder and don't put other files in it.
+
+### Watched folder
+
+When set, Neural Composer watches this vault folder for file changes. Every time you save a note inside it, the plugin queues it for re-ingestion (with a 5-second debounce). Renames and deletes are also handled: a renamed note is re-ingested under its new name, and a deleted note is removed from the graph.
+
+Leave this blank if you prefer to ingest manually via right-click.
+
+### Graph logic model
+
+The LLM used by LightRAG internally to extract entities and relationships during ingestion. This is separate from your chat model. A cost-efficient model (e.g., `gemini-flash` or `gpt-4o-mini`) is usually fine here.
+
+### Embedding model (server-side)
+
+The embedding model LightRAG uses on the server side. Must be consistent with what was used when the graph was first built. Changing this and re-ingesting will rebuild the vector index.
+
+### Summary language
+
+The language LightRAG uses when writing entity summaries into the graph. Defaults to English. Change this if your notes are primarily in another language.
+
+### Citations toggle
+
+When enabled, chat responses include numbered citation markers (e.g., `[1]`) linked to the source documents and text chunks that were retrieved. Disable if you find citations cluttering the output.
+
+### Auto-start
+
+When on, the plugin starts `lightrag-server` automatically when Obsidian opens, and stops it when Obsidian closes. Recommended for most users.
+
+---
+
+## Advanced
+
+### .env editor
+
+LightRAG is configured via a `.env` file in its data directory. The Advanced tab includes a text editor for this file so you can set options that the UI doesn't expose directly (e.g., `LIGHTRAG_KV_STORAGE`, `LIGHTRAG_GRAPH_STORAGE`).
+
+### Custom environment variables
+
+Add arbitrary `KEY=VALUE` pairs that are injected into the LightRAG server's environment on startup. Useful for proxy settings or provider-specific options.
+
+### Performance tuning
+
+| Setting          | What it does                                                                                       |
+| :--------------- | :------------------------------------------------------------------------------------------------- |
+| **Chunk size**   | How many characters each text chunk contains before being embedded. Larger = more context per chunk, but more tokens per embedding call. |
+| **Chunk overlap** | How many characters overlap between consecutive chunks. Helps avoid splitting concepts across chunk boundaries. |
+| **Async workers** | Number of parallel workers LightRAG uses during ingestion. Higher = faster ingestion, higher API concurrency. |
+
+---
+
+## Tools (MCP)
+
+Neural Composer can expose your vault's knowledge graph to external AI clients via the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+### Adding an MCP server
+
+Each MCP server entry has:
+
+- **Name** — A label for your own reference.
+- **Transport** — `stdio` or `sse`. Use `stdio` for local clients (Claude Desktop); use `sse` for network-accessible servers.
+- **Command / URL** — For `stdio`: the command to launch the MCP client bridge. For `sse`: the URL of the SSE endpoint.
+- **Arguments** — Additional arguments passed to the command (stdio only).
+- **Environment** — Key/value pairs injected when the command is started (stdio only).
+
+### Claude Desktop example
+
+To expose your graph to Claude Desktop, add an entry with transport `stdio` and point the command at the Neural Composer MCP bridge. Then add the corresponding entry in Claude Desktop's `claude_desktop_config.json`. The wiki [Features](Features) page has more detail.
+
+---
+
+## Help
+
+The Help tab contains quick-start guidance, links to this wiki, and the plugin version. Nothing to configure here — it's a reference panel you can open without leaving Obsidian.

--- a/wiki/Custom-Ontology.md
+++ b/wiki/Custom-Ontology.md
@@ -1,0 +1,134 @@
+# Custom Ontology
+
+By default, LightRAG extracts a broad set of entity types from your notes: `Person`, `Organization`, `Location`, `Event`, `Concept`, and so on. Custom Ontology lets you replace this default set with types specific to your domain, so the graph reflects the vocabulary of your work.
+
+---
+
+## Why it matters
+
+The entity types you define shape what LightRAG pays attention to during ingestion. With the default types, a machine learning researcher's notes will generate `Person` (authors) and `Concept` (algorithms), but miss domain-specific categories like `Dataset`, `Experiment`, or `Benchmark`. A novelist's notes will miss `Character` and `PlotArc`.
+
+Defining the right entity types produces a graph that is:
+- More precisely structured around your domain
+- Better at multi-hop reasoning across domain-specific relationships
+- Easier to explore in the graph visualization (nodes are categorized correctly)
+
+---
+
+## LightRAG v1.4.x — inline entity types
+
+> If you are on LightRAG v1.5+, skip to the next section.
+
+1. Open **Settings → Neural Composer → Graph & Vault → Ontology**.
+2. Toggle **Use custom entity types** on.
+3. Edit the comma-separated list in the textarea.
+
+[screenshot: Ontology section with toggle enabled and a textarea containing "Person, Dataset, Experiment, Benchmark, Method, Paper, Institution"]
+
+**Format:** comma-separated type names, singular, title-case. Example:
+
+```
+Person, Organization, Dataset, Experiment, Method, Benchmark, Paper, Venue, Metric
+```
+
+LightRAG will prioritize extracting entities of these types. Types you omit will still be extracted occasionally if LightRAG finds a clear match, but the focus shifts to your list.
+
+### Tips for choosing entity types
+
+- **Keep it to 8–15 types.** Too many reduces extraction precision.
+- **Use singular forms.** `Person` not `People`.
+- **Be specific enough to be useful, but not so narrow that nothing matches.** `ResearchPaper` is better than `ArxivPaper2024`.
+- **Test with a small folder first** before re-ingesting your entire vault.
+
+### Domain examples
+
+| Domain | Suggested entity types |
+| :--- | :--- |
+| Academic research | `Person, Institution, Paper, Dataset, Method, Benchmark, Metric, Concept, Venue` |
+| Fiction writing | `Character, Location, Organization, Event, Artifact, Concept, PlotArc` |
+| Software engineering | `System, Component, API, Concept, Person, Organization, Technology, Issue` |
+| Game mastering (TTRPG) | `Character, Faction, Location, Artifact, Event, Creature, Lore, Session` |
+| Personal knowledge | `Person, Concept, Project, Resource, Idea, Decision, Event` |
+
+---
+
+## LightRAG v1.5+ — jinja2 template file
+
+LightRAG v1.5.0 replaced the `ENTITY_TYPES` environment variable with a file-based approach. Instead of a comma-separated list, you provide a **jinja2 template** that LightRAG uses when prompting the LLM during extraction.
+
+When Neural Composer detects a v1.5+ server, the Ontology textarea is replaced with a **file path** field, and a migration banner appears in settings.
+
+[screenshot: migration banner in Graph & Vault settings reading "⚡ LightRAG v1.5 detected — entity types now require a template file", with the new file path input below]
+
+### Step 1 — Create the template file
+
+Create a file called `entity_types.jinja2` (or any name you prefer) in your **Data Directory** — the same folder LightRAG uses to store the graph. The simplest template looks like this:
+
+```jinja2
+Your goal is to extract structured information from the following text.
+Extract only entities of these types: {{ entity_types }}.
+
+Focus on:
+- Relationships between entities
+- Properties and attributes of each entity
+- Temporal or causal relationships where present
+
+Text:
+{{ input_text }}
+```
+
+LightRAG injects `entity_types` and `input_text` at runtime.
+
+### Step 2 — Define your entity types in the template
+
+To hardcode your custom types, replace `{{ entity_types }}` with your list directly:
+
+```jinja2
+Your goal is to extract structured information from the following text.
+Extract only entities of these types:
+Person, Dataset, Experiment, Method, Benchmark, Paper, Institution, Metric, Venue.
+
+Focus on relationships, attributes, and temporal connections between these entities.
+
+Text:
+{{ input_text }}
+```
+
+### Step 3 — Point Neural Composer at the file
+
+In **Settings → Graph & Vault → Ontology**, enter the full absolute path to the template file:
+
+```
+/Users/you/lightrag-data/entity_types.jinja2
+```
+
+[screenshot: Ontology section on v1.5+ — file path field with a path entered and a small "Verify file" button]
+
+Click **Restart Server** to apply the change.
+
+### Step 4 — Re-ingest your notes
+
+Entity types only affect ingestion, not querying. After changing your template, you need to re-ingest notes for the new types to take effect. Right-click the watched folder → **Add to graph** to queue everything.
+
+---
+
+## Changing entity types on an existing graph
+
+**You don't need to delete the graph to change entity types.** New and re-ingested notes will use the new types. Existing nodes in the graph retain their original types until those notes are re-ingested.
+
+If you want the entire graph to use the new types:
+1. Change the entity types / template.
+2. Delete the LightRAG data directory contents (or use a fresh directory).
+3. Re-ingest all notes.
+
+This is a destructive operation — the graph is rebuilt from scratch — but it's the only way to guarantee consistency across all nodes.
+
+---
+
+## Ontology folder (optional)
+
+The **Ontology folder** field (Settings → Graph & Vault → Ontology) lets you point LightRAG at a folder of additional context documents that inform entity extraction. For example, a folder of domain glossaries or reference documents.
+
+LightRAG reads these files once at startup and uses them to improve entity disambiguation. This field is optional and separate from the template file.
+
+[screenshot: Ontology section showing both the entity types file path field and the Ontology folder field below it]

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -1,0 +1,97 @@
+# Features
+
+Deep dives into each major feature of Neural Composer.
+
+---
+
+## Chat with Graph
+
+The chat pane is the primary interface for querying your knowledge graph. Open it via the ribbon icon or the command palette (`Neural Composer: Open chat`).
+
+### Query modes
+
+LightRAG supports several retrieval strategies. You can select the mode from the dropdown in the chat toolbar:
+
+| Mode       | What it does                                                                                                              |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------ |
+| **local**  | Retrieves the most relevant text chunks by vector similarity. Fast; best for precise factual questions.                   |
+| **global** | Traverses the knowledge graph to find entity relationships. Best for broad, synthesizing questions.                       |
+| **hybrid** | Combines local and global. The recommended default for most questions.                                                    |
+| **naive**  | Plain vector search without graph traversal. Useful for comparing output quality against the graph-aware modes.           |
+| **mix**    | A weighted blend of all strategies. Can produce the richest answers but uses more tokens.                                 |
+| **bypass** | Skips retrieval entirely and sends your message directly to the LLM. Useful for general questions unrelated to your vault. |
+
+### Citations
+
+When citations are enabled (Settings → Graph & Vault → Citations), each response includes numbered markers like `[1]`. Click a marker to jump to the source chunk and the file it came from. This lets you verify any claim the model makes.
+
+---
+
+## Document Status Tracking
+
+Every note that has been through the ingestion pipeline has a status tracked by the plugin. Status is shown as a colored dot in the file explorer, next to the file name.
+
+### What the dots mean
+
+| Color | Status      | Meaning                                                                                     |
+| :---- | :---------- | :------------------------------------------------------------------------------------------ |
+| 🟢    | processed   | The note has been successfully ingested and is part of the knowledge graph.                 |
+| 🟡    | processing  | The note is currently queued or being ingested. Also shown if the last ingestion failed.    |
+| 🔴    | failed      | Ingestion completed but an error was recorded. Re-process to retry.                        |
+| 🔵    | removed     | The note was explicitly removed from the graph (via right-click → Remove from graph).       |
+
+The watched folder itself shows an **aggregate dot**: green if all notes inside are processed, yellow if any are pending or failed, and so on.
+
+### How to re-process a note
+
+Right-click the file in the file explorer and choose **Add to graph**. This queues it for ingestion regardless of its current status.
+
+### How to remove a note from the graph
+
+Right-click the file and choose **Remove from graph**. The dot turns blue and the note's data is deleted from the LightRAG index.
+
+---
+
+## Knowledge Graph Visualization
+
+Open the graph view via the command palette: `Neural Composer: Open knowledge graph`. The view opens as a new pane inside Obsidian.
+
+### Overview mode
+
+Renders all entities (nodes) and relationships (edges) currently in the graph. Node size reflects the number of connections. Useful for getting a bird's-eye view of how your ideas cluster.
+
+Use the toolbar to switch between **2D** (canvas-based, faster) and **3D** (WebGL, more immersive). In 3D, you can orbit, zoom, and pan with the mouse.
+
+### Explore mode
+
+Click **Explore** in the toolbar and type an entity name. The view performs a breadth-first search (BFS) from that entity, showing its immediate neighbors and then their neighbors, up to a configurable depth. This lets you trace how a specific idea connects to the rest of your vault without drowning in the full graph.
+
+Click any node to re-center the BFS on that entity.
+
+---
+
+## Vault Sync
+
+Vault Sync keeps the knowledge graph in step with your notes as you write, without manual ingestion steps.
+
+### Setup
+
+Set a **Watched Folder** in Settings → Graph & Vault. This should be a vault folder (or the vault root) that contains the notes you want to keep indexed.
+
+### Auto-re-index on save
+
+Whenever you save a note inside the watched folder, Neural Composer queues it for re-ingestion. A **5-second debounce** prevents rapid saves (e.g., while typing) from flooding the server — only the final save after you stop typing triggers the ingestion.
+
+The status dot next to the file turns 🟡 while ingestion is in progress and 🟢 when it completes.
+
+### Rename handling
+
+If you rename a note, the plugin removes the old document from the graph and re-ingests it under the new name. Relationships established under the old name are rebuilt.
+
+### Delete handling
+
+If you delete a note, it is automatically removed from the graph. The status dot disappears along with the file.
+
+### Disabling auto-sync
+
+To stop watching a folder, clear the **Watched Folder** field in settings. You can still ingest notes manually at any time via right-click → Add to graph.

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -196,11 +196,13 @@ POST /rerank
 
 ## MCP Tools
 
-Neural Composer can expose your vault's knowledge graph to any client that supports the [Model Context Protocol](https://modelcontextprotocol.io/). This lets external AI agents — Claude Desktop, Cursor, or custom scripts — query your graph programmatically.
+Neural Composer connects to external [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) servers and makes their tools available inside the chat pane. This lets you combine your vault graph with external capabilities — GitHub, web search, filesystem access, and more — in a single conversation.
 
-[screenshot: Tools (MCP) tab showing a configured server entry with name, transport, and command visible]
+> Neural Composer is an MCP **client**. It connects *to* external servers; it does not expose itself as a server to applications like Claude Desktop.
 
-For a full setup guide, see the [MCP Tools](MCP-Tools) page.
+[screenshot: Tools (MCP) tab showing a configured server entry with name and command visible]
+
+For setup instructions and examples, see the [MCP Tools](MCP-Tools) page.
 
 ---
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -8,22 +8,67 @@ Deep dives into each major feature of Neural Composer.
 
 The chat pane is the primary interface for querying your knowledge graph. Open it via the ribbon icon or the command palette (`Neural Composer: Open chat`).
 
+[screenshot: chat pane — full view showing the input field, a query, and a response with citation markers]
+
 ### Query modes
 
-LightRAG supports several retrieval strategies. You can select the mode from the dropdown in the chat toolbar:
+LightRAG supports several retrieval strategies. Select the mode from the dropdown in the chat toolbar — or set a default in **Settings → Neural Composer → Graph & Vault → Query mode**.
 
 | Mode       | What it does                                                                                                              |
 | :--------- | :------------------------------------------------------------------------------------------------------------------------ |
 | **local**  | Retrieves the most relevant text chunks by vector similarity. Fast; best for precise factual questions.                   |
 | **global** | Traverses the knowledge graph to find entity relationships. Best for broad, synthesizing questions.                       |
-| **hybrid** | Combines local and global. The recommended default for most questions.                                                    |
-| **naive**  | Plain vector search without graph traversal. Useful for comparing output quality against the graph-aware modes.           |
-| **mix**    | A weighted blend of all strategies. Can produce the richest answers but uses more tokens.                                 |
-| **bypass** | Skips retrieval entirely and sends your message directly to the LLM. Useful for general questions unrelated to your vault. |
+| **hybrid** | Combines local and global. A strong general-purpose default.                                                              |
+| **naive**  | Plain vector search without graph traversal. Useful for comparing output quality against graph-aware modes.               |
+| **mix**    | Weighted blend of all strategies. Can produce the richest answers but uses more tokens.                                   |
+| **bypass** | Skips retrieval entirely — sends your message straight to the LLM. Useful for general questions unrelated to your vault.  |
+
+[screenshot: query mode dropdown in the chat toolbar, open, showing the six options]
 
 ### Citations
 
 When citations are enabled (Settings → Graph & Vault → Citations), each response includes numbered markers like `[1]`. Click a marker to jump to the source chunk and the file it came from. This lets you verify any claim the model makes.
+
+[screenshot: chat response with [1] [2] citation markers visible, and the "Context used" panel open below showing source file names and relevance scores]
+
+### Chat options
+
+The toolbar also exposes three toggles that apply to the current session:
+
+| Toggle | What it does |
+| :--- | :--- |
+| **Include current file** | Attaches the content of the note open in the editor to your message. |
+| **Enable tools** | Lets the model call MCP tools and built-in vault tools (read, edit, create notes). |
+
+### System prompt
+
+Set a standing instruction in **Settings → Chat → System prompt**. It is prepended to every request before your message. Examples:
+- `Always answer in Spanish.`
+- `Be concise. No bullet points.`
+- `You are my research assistant for machine learning papers.`
+
+---
+
+## Right-click context menu
+
+Neural Composer adds actions to the file explorer's right-click menu for both folders and individual files.
+
+[screenshot: right-click context menu on a vault folder, showing "Add to graph" and other Neural Composer options]
+
+### On a folder
+
+| Action | What it does |
+| :--- | :--- |
+| **Add to graph** | Recursively ingests all supported files in the folder and its subfolders. |
+
+### On a file
+
+| Action | What it does |
+| :--- | :--- |
+| **Add to graph** | Ingests this single file, regardless of its current status. |
+| **Remove from graph** | Deletes this file's data from the LightRAG index. The status dot turns 🔵. The file itself is not deleted. |
+
+> **Supported formats:** `md` `txt` `docx` `pdf` `pptx` `xlsx` `rtf` `odt` `epub` `html` `htm` `xml` `json` `yaml` `yml` `csv` `tex` `log` `conf` `ini` `properties` `sql` `bat` `sh` `c` `cpp` `py` `java` `js` `ts` `swift` `go` `rb` `php` `css` `scss` `less`
 
 ---
 
@@ -31,24 +76,24 @@ When citations are enabled (Settings → Graph & Vault → Citations), each resp
 
 Every note that has been through the ingestion pipeline has a status tracked by the plugin. Status is shown as a colored dot in the file explorer, next to the file name.
 
+[screenshot: file explorer panel showing several notes with colored dots (green, yellow, red, blue) next to their names]
+
 ### What the dots mean
 
 | Color | Status      | Meaning                                                                                     |
 | :---- | :---------- | :------------------------------------------------------------------------------------------ |
 | 🟢    | processed   | The note has been successfully ingested and is part of the knowledge graph.                 |
-| 🟡    | processing  | The note is currently queued or being ingested. Also shown if the last ingestion failed.    |
+| 🟡    | processing  | The note is currently queued or being ingested.                                             |
 | 🔴    | failed      | Ingestion completed but an error was recorded. Re-process to retry.                        |
 | 🔵    | removed     | The note was explicitly removed from the graph (via right-click → Remove from graph).       |
 
-The watched folder itself shows an **aggregate dot**: green if all notes inside are processed, yellow if any are pending or failed, and so on.
+The watched folder itself shows an **aggregate dot**: 🟢 if all notes inside are processed, 🟡 if any are pending or failed.
 
-### How to re-process a note
+### Reprocess failed documents
 
-Right-click the file in the file explorer and choose **Add to graph**. This queues it for ingestion regardless of its current status.
+In **Settings → Graph & Vault**, the **Reprocess failed documents** button re-queues every file currently marked 🔴 for a fresh ingestion attempt. Useful after fixing an API key error or network issue that caused batch failures.
 
-### How to remove a note from the graph
-
-Right-click the file and choose **Remove from graph**. The dot turns blue and the note's data is deleted from the LightRAG index.
+[screenshot: "Reprocess failed documents" button in the Graph & Vault settings tab]
 
 ---
 
@@ -56,17 +101,34 @@ Right-click the file and choose **Remove from graph**. The dot turns blue and th
 
 Open the graph view via the command palette: `Neural Composer: Open knowledge graph`. The view opens as a new pane inside Obsidian.
 
+[screenshot: graph view in Overview mode — showing a 2D force-directed graph with colored nodes and labeled edges]
+
 ### Overview mode
 
 Renders all entities (nodes) and relationships (edges) currently in the graph. Node size reflects the number of connections. Useful for getting a bird's-eye view of how your ideas cluster.
 
 Use the toolbar to switch between **2D** (canvas-based, faster) and **3D** (WebGL, more immersive). In 3D, you can orbit, zoom, and pan with the mouse.
 
+[screenshot: 3D graph view — nodes floating in space with glow effects, mouse cursor near a node]
+
 ### Explore mode
 
-Click **Explore** in the toolbar and type an entity name. The view performs a breadth-first search (BFS) from that entity, showing its immediate neighbors and then their neighbors, up to a configurable depth. This lets you trace how a specific idea connects to the rest of your vault without drowning in the full graph.
+Click **Explore** in the toolbar and type an entity name. The view performs a breadth-first search (BFS) from that entity, showing its immediate neighbors and then their neighbors up to a configurable depth. This lets you trace how a specific idea connects to the rest of your vault without drowning in the full graph.
 
 Click any node to re-center the BFS on that entity.
+
+[screenshot: Explore mode — one central node highlighted, with first- and second-degree neighbors visible, BFS depth indicator in the toolbar]
+
+### 2D vs. 3D rendering
+
+| | 2D | 3D |
+|:---|:---|:---|
+| **Rendering** | Canvas (CPU) | WebGL (GPU) |
+| **Performance** | Fast even on large graphs | Heavier; best for < 5 000 nodes |
+| **Interaction** | Pan + zoom | Orbit + zoom + pan |
+| **Recommended for** | Daily use, large vaults | Exploration and presentations |
+
+Switch in **Settings → Graph & Vault → Graph rendering engine**.
 
 ---
 
@@ -78,20 +140,74 @@ Vault Sync keeps the knowledge graph in step with your notes as you write, witho
 
 Set a **Watched Folder** in Settings → Graph & Vault. This should be a vault folder (or the vault root) that contains the notes you want to keep indexed.
 
+[screenshot: "Watched folder" field in Graph & Vault settings with a folder path entered]
+
 ### Auto-re-index on save
 
-Whenever you save a note inside the watched folder, Neural Composer queues it for re-ingestion. A **5-second debounce** prevents rapid saves (e.g., while typing) from flooding the server — only the final save after you stop typing triggers the ingestion.
+Whenever you save a note inside the watched folder, Neural Composer queues it for re-ingestion. A **5-second debounce** prevents rapid saves (e.g., while typing) from flooding the server — only the final save after you stop triggers ingestion.
 
 The status dot next to the file turns 🟡 while ingestion is in progress and 🟢 when it completes.
 
-### Rename handling
+### Rename and delete handling
 
-If you rename a note, the plugin removes the old document from the graph and re-ingests it under the new name. Relationships established under the old name are rebuilt.
-
-### Delete handling
-
-If you delete a note, it is automatically removed from the graph. The status dot disappears along with the file.
+| Event | What happens |
+| :--- | :--- |
+| **Rename** | The old document is removed from the graph and re-ingested under the new name. |
+| **Delete** | The note is automatically removed from the graph. The status dot disappears with the file. |
+| **Move** | Treated as a delete + rename — removed from the old path, re-ingested at the new path. |
 
 ### Disabling auto-sync
 
-To stop watching a folder, clear the **Watched Folder** field in settings. You can still ingest notes manually at any time via right-click → Add to graph.
+Clear the **Watched Folder** field in settings. You can still ingest notes manually at any time via right-click → **Add to graph**.
+
+---
+
+## Reranking
+
+Reranking runs a second-pass scoring model over the chunks retrieved from the graph before the LLM sees them. This improves result quality — especially on large graphs where the initial retrieval may surface marginally relevant chunks.
+
+[screenshot: Reranking section in Graph & Vault settings — provider set to "Jina AI" with model and API key fields filled]
+
+### When to use it
+
+- Your graph has more than ~1 000 nodes and answers feel imprecise.
+- You are using `mix` mode (all strategies) and want to filter down the best chunks.
+- You have access to a local reranker (e.g., a FastAPI server wrapping a `cross-encoder` model) and want zero data leaving your machine.
+
+### Supported providers
+
+| Provider | Notes |
+| :--- | :--- |
+| **Jina AI** | Cloud. Default model: `jina-reranker-v2-base-multilingual`. Multilingual, good general-purpose. |
+| **Cohere** | Cloud. Default model: `rerank-english-v3.0`. Strong on English technical content. |
+| **Custom** | Any HTTP endpoint that accepts a list of (query, passage) pairs and returns ranked scores. |
+
+### Custom local endpoint
+
+Point **Host** at your local reranking server (e.g., `http://localhost:8080/rerank`). The API contract Neural Composer expects:
+
+```
+POST /rerank
+{ "query": "...", "documents": ["...", "..."] }
+→ { "results": [{ "index": 0, "score": 0.91 }, ...] }
+```
+
+---
+
+## MCP Tools
+
+Neural Composer can expose your vault's knowledge graph to any client that supports the [Model Context Protocol](https://modelcontextprotocol.io/). This lets external AI agents — Claude Desktop, Cursor, or custom scripts — query your graph programmatically.
+
+[screenshot: Tools (MCP) tab showing a configured server entry with name, transport, and command visible]
+
+For a full setup guide, see the [MCP Tools](MCP-Tools) page.
+
+---
+
+## Custom Ontology
+
+By default, LightRAG extracts a broad set of entity types from your notes. Custom Ontology lets you teach it the vocabulary of your specific domain.
+
+[screenshot: Ontology section in Graph & Vault — toggle enabled, textarea showing custom types like "Experiment, Theorem, Reagent, Author"]
+
+For a full guide, see the [Custom Ontology](Custom-Ontology) page.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,12 +8,29 @@ Welcome to the Neural Composer wiki. This is the best place to go deeper than th
 
 ## Pages
 
-| Page                               | What's inside                                                                |
-| :--------------------------------- | :--------------------------------------------------------------------------- |
-| [Installation](Installation)       | Prerequisites, Python setup, plugin install, first-run checklist            |
-| [Configuration](Configuration)     | Every settings tab explained in detail (Providers, Models, Chat, Graph & Vault, MCP, Advanced) |
-| [Features](Features)               | Deep dives into Chat, Document Status, Graph Visualization, and Vault Sync   |
-| [Troubleshooting](Troubleshooting) | Fixes for the most common problems                                           |
+### Getting started
+
+| Page | What's inside |
+| :--- | :--- |
+| [Installation](Installation) | Prerequisites, Python setup, plugin install, first-run checklist |
+| [Providers Guide](Providers-Guide) | Per-provider setup: API keys, recommended models, known quirks |
+| [Configuration](Configuration) | Every settings tab explained in detail |
+
+### Features
+
+| Page | What's inside |
+| :--- | :--- |
+| [Features](Features) | Chat, Document Status, Graph Visualization, Vault Sync, Reranking, MCP Tools |
+| [MCP Tools](MCP-Tools) | Connecting Claude Desktop and other MCP clients to your vault graph |
+| [Custom Ontology](Custom-Ontology) | Teaching the graph your domain's entity types (v1.4 and v1.5+) |
+| [Reranking](Reranking) | Improving retrieval quality with Jina AI, Cohere, or a local reranker |
+| [Remote Server](Remote-Server) | Running LightRAG on a NAS, VPS, or Docker container |
+
+### Support
+
+| Page | What's inside |
+| :--- | :--- |
+| [Troubleshooting](Troubleshooting) | Fixes for the most common problems |
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,12 +8,12 @@ Welcome to the Neural Composer wiki. This is the best place to go deeper than th
 
 ## Pages
 
-| Page                                      | What's inside                                                                        |
-| :---------------------------------------- | :----------------------------------------------------------------------------------- |
-| [Installation](Installation)              | Prerequisites, Python setup, plugin install (BRAT + manual), first-run checklist    |
-| [Configuration](Configuration)            | Every settings tab explained in detail                                               |
-| [Features](Features)                      | Deep dives into Chat, Document Status, Graph Visualization, and Vault Sync           |
-| [Troubleshooting](Troubleshooting)        | Fixes for the most common problems                                                   |
+| Page                               | What's inside                                                                     |
+| :--------------------------------- | :-------------------------------------------------------------------------------- |
+| [Installation](Installation)       | Prerequisites, Python setup, plugin install (BRAT + manual), first-run checklist |
+| [Configuration](Configuration)     | Every settings tab explained in detail                                            |
+| [Features](Features)               | Deep dives into Chat, Document Status, Graph Visualization, and Vault Sync        |
+| [Troubleshooting](Troubleshooting) | Fixes for the most common problems                                                |
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,12 +8,12 @@ Welcome to the Neural Composer wiki. This is the best place to go deeper than th
 
 ## Pages
 
-| Page                               | What's inside                                                                     |
-| :--------------------------------- | :-------------------------------------------------------------------------------- |
-| [Installation](Installation)       | Prerequisites, Python setup, plugin install (BRAT + manual), first-run checklist |
-| [Configuration](Configuration)     | Every settings tab explained in detail                                            |
-| [Features](Features)               | Deep dives into Chat, Document Status, Graph Visualization, and Vault Sync        |
-| [Troubleshooting](Troubleshooting) | Fixes for the most common problems                                                |
+| Page                               | What's inside                                                                |
+| :--------------------------------- | :--------------------------------------------------------------------------- |
+| [Installation](Installation)       | Prerequisites, Python setup, plugin install, first-run checklist            |
+| [Configuration](Configuration)     | Every settings tab explained in detail (Providers, Models, Chat, Graph & Vault, MCP, Advanced) |
+| [Features](Features)               | Deep dives into Chat, Document Status, Graph Visualization, and Vault Sync   |
+| [Troubleshooting](Troubleshooting) | Fixes for the most common problems                                           |
 
 ---
 
@@ -21,7 +21,7 @@ Welcome to the Neural Composer wiki. This is the best place to go deeper than th
 
 Download the latest version from the [Releases page](https://github.com/oscampo/obsidian-neural-composer/releases).
 
-The changelog for each version is attached to its release. v1.3.x introduced Vault Sync, Remote Server support, Knowledge Graph Visualization, and MCP Tools.
+The changelog for each version is attached to its release. v1.3.x introduced Vault Sync, Document Status tracking, Knowledge Graph Visualization, and MCP Tools.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,32 @@
+# Neural Composer Wiki
+
+Welcome to the Neural Composer wiki. This is the best place to go deeper than the README.
+
+**Neural Composer** is an Obsidian plugin that builds a knowledge graph of your vault using [LightRAG](https://github.com/HKUDS/LightRAG), then lets you chat with it using any major AI provider. It goes beyond keyword or vector search by following the _relationships_ between your ideas.
+
+---
+
+## Pages
+
+| Page                                      | What's inside                                                                        |
+| :---------------------------------------- | :----------------------------------------------------------------------------------- |
+| [Installation](Installation)              | Prerequisites, Python setup, plugin install (BRAT + manual), first-run checklist    |
+| [Configuration](Configuration)            | Every settings tab explained in detail                                               |
+| [Features](Features)                      | Deep dives into Chat, Document Status, Graph Visualization, and Vault Sync           |
+| [Troubleshooting](Troubleshooting)        | Fixes for the most common problems                                                   |
+
+---
+
+## Releases
+
+Download the latest version from the [Releases page](https://github.com/oscampo/obsidian-neural-composer/releases).
+
+The changelog for each version is attached to its release. v1.3.x introduced Vault Sync, Remote Server support, Knowledge Graph Visualization, and MCP Tools.
+
+---
+
+## Quick links
+
+- [GitHub repository](https://github.com/oscampo/obsidian-neural-composer)
+- [Report an issue](https://github.com/oscampo/obsidian-neural-composer/issues)
+- [LightRAG upstream](https://github.com/HKUDS/LightRAG)

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,97 @@
+# Installation
+
+This page walks you through the full setup from scratch.
+
+---
+
+## Prerequisites
+
+| Requirement           | Minimum version | Notes                                              |
+| :-------------------- | :-------------- | :------------------------------------------------- |
+| **Python**            | 3.10            | 3.11 or 3.12 recommended                          |
+| **Obsidian**          | 1.7.2           | Desktop only (mobile is not supported)            |
+| **pip**               | any recent      | Comes with Python; update with `pip install -U pip` |
+
+---
+
+## Step 1 — Install LightRAG
+
+LightRAG ships a ready-to-use API server. Install it with:
+
+```bash
+pip install "lightrag-hku[api]"
+```
+
+**We strongly recommend a virtual environment** so this doesn't interfere with other Python projects:
+
+```bash
+python -m venv ~/.venvs/lightrag
+source ~/.venvs/lightrag/bin/activate      # macOS / Linux
+# or
+~\.venvs\lightrag\Scripts\activate         # Windows PowerShell
+
+pip install "lightrag-hku[api]"
+```
+
+Once installed, verify the server binary exists:
+
+```bash
+lightrag-server --version
+```
+
+---
+
+## Step 2 — Find the `lightrag-server` path
+
+The plugin needs the **absolute path** to the `lightrag-server` executable. Find it with:
+
+```bash
+# macOS / Linux
+which lightrag-server
+# example output: /Users/you/.venvs/lightrag/bin/lightrag-server
+
+# Windows (PowerShell)
+where.exe lightrag-server
+# example output: C:\Users\you\.venvs\lightrag\Scripts\lightrag-server.exe
+```
+
+Copy this path — you will paste it into the plugin settings in Step 4.
+
+> **Tip:** If you used a virtual environment, the path lives inside the venv's `bin/` (macOS/Linux) or `Scripts/` (Windows) directory. You must use the full absolute path, not just `lightrag-server`, because the plugin does not inherit your shell's `PATH`.
+
+---
+
+## Step 3 — Install the plugin
+
+### Option A: BRAT (recommended)
+
+[BRAT](https://github.com/TfTHacker/obsidian42-brat) lets you install and update Neural Composer directly from GitHub without waiting for the community plugin store.
+
+1. Install **BRAT** from the Obsidian community plugin store.
+2. Open BRAT settings and click **Add Beta Plugin**.
+3. Paste `oscampo/obsidian-neural-composer` and confirm.
+4. BRAT downloads and enables the plugin automatically.
+
+### Option B: Manual install
+
+1. Go to the [Releases page](https://github.com/oscampo/obsidian-neural-composer/releases) and download `main.js`, `manifest.json`, and `styles.css` from the latest release.
+2. Create the folder `.obsidian/plugins/neural-composer` inside your vault (create it if it doesn't exist).
+3. Copy the three files into that folder.
+4. In Obsidian: **Settings → Community plugins → Installed plugins**, find Neural Composer and toggle it on.
+
+---
+
+## Step 4 — First-run checklist
+
+After enabling the plugin, open **Settings → Neural Composer** and work through this list:
+
+- [ ] **Providers tab** — Enter at least one AI provider API key (or configure Ollama if you want a fully local setup).
+- [ ] **Models tab** — Select a chat model and an embedding model.
+- [ ] **Graph & Vault tab** — Paste the `lightrag-server` path from Step 2 into the **Command Path** field.
+- [ ] **Graph & Vault tab** — Choose a **Data Directory** where the graph files will be stored (can be anywhere on disk, does not need to be inside the vault).
+- [ ] **Graph & Vault tab** — Optionally set a **Watched Folder** to enable auto-sync.
+- [ ] Toggle **Auto-start** to on.
+- [ ] Click **Restart Server** and wait for the status bar dot to turn green.
+- [ ] Right-click a folder in the file explorer and choose **Add to graph** to ingest your first notes.
+
+If the status bar dot stays red, see the [Troubleshooting](Troubleshooting) page.

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -6,11 +6,11 @@ This page walks you through the full setup from scratch.
 
 ## Prerequisites
 
-| Requirement           | Minimum version | Notes                                              |
-| :-------------------- | :-------------- | :------------------------------------------------- |
-| **Python**            | 3.10            | 3.11 or 3.12 recommended                          |
-| **Obsidian**          | 1.7.2           | Desktop only (mobile is not supported)            |
-| **pip**               | any recent      | Comes with Python; update with `pip install -U pip` |
+| Requirement  | Minimum version | Notes                                               |
+| :----------- | :-------------- | :-------------------------------------------------- |
+| **Python**   | 3.10            | 3.11 or 3.12 recommended                           |
+| **Obsidian** | 1.7.2           | Desktop only (mobile is not supported)             |
+| **pip**      | any recent      | Comes with Python; update with `pip install -U pip` |
 
 ---
 

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -16,13 +16,7 @@ This page walks you through the full setup from scratch.
 
 ## Step 1 — Install LightRAG
 
-LightRAG ships a ready-to-use API server. Install it with:
-
-```bash
-pip install "lightrag-hku[api]"
-```
-
-**We strongly recommend a virtual environment** so this doesn't interfere with other Python projects:
+LightRAG ships a ready-to-use API server. **We strongly recommend a virtual environment** to keep it isolated from other Python projects:
 
 ```bash
 python -m venv ~/.venvs/lightrag
@@ -38,6 +32,8 @@ Once installed, verify the server binary exists:
 ```bash
 lightrag-server --version
 ```
+
+> **Windows note:** If `python` is not found, try `python3` or use the full path from the Microsoft Store install. On some Windows setups, `py -3.11 -m venv` is more reliable.
 
 ---
 
@@ -57,41 +53,56 @@ where.exe lightrag-server
 
 Copy this path — you will paste it into the plugin settings in Step 4.
 
-> **Tip:** If you used a virtual environment, the path lives inside the venv's `bin/` (macOS/Linux) or `Scripts/` (Windows) directory. You must use the full absolute path, not just `lightrag-server`, because the plugin does not inherit your shell's `PATH`.
+> **Tip:** If you used a virtual environment, the path lives inside the venv's `bin/` (macOS/Linux) or `Scripts/` (Windows) directory. You must use the full absolute path, not just `lightrag-server`, because the plugin does not inherit your shell's `PATH`. Paths with spaces must be wrapped in quotes in some OS configurations.
 
 ---
 
 ## Step 3 — Install the plugin
 
-### Option A: BRAT (recommended)
+### Option A: Community Plugin Store (recommended)
 
-[BRAT](https://github.com/TfTHacker/obsidian42-brat) lets you install and update Neural Composer directly from GitHub without waiting for the community plugin store.
+Neural Composer is published on the official Obsidian community plugin marketplace.
 
-1. Install **BRAT** from the Obsidian community plugin store.
-2. Open BRAT settings and click **Add Beta Plugin**.
-3. Paste `oscampo/obsidian-neural-composer` and confirm.
-4. BRAT downloads and enables the plugin automatically.
+1. In Obsidian, open **Settings → Community plugins**.
+2. Make sure **Restricted mode** is off.
+3. Click **Browse** and search for **"Neural Composer"**.
+4. Click **Install**, then **Enable**.
+
+[screenshot: Obsidian Community plugins Browse panel with "Neural Composer" in the search field and the Install button visible]
 
 ### Option B: Manual install
 
-1. Go to the [Releases page](https://github.com/oscampo/obsidian-neural-composer/releases) and download `main.js`, `manifest.json`, and `styles.css` from the latest release.
-2. Create the folder `.obsidian/plugins/neural-composer` inside your vault (create it if it doesn't exist).
-3. Copy the three files into that folder.
+Use this if you need a specific release that isn't yet on the store, or want to test a pre-release build.
+
+1. Go to the [Releases page](https://github.com/oscampo/obsidian-neural-composer/releases) and download `main.js`, `manifest.json`, and `styles.css` from the desired release.
+2. In your vault, create the folder `.obsidian/plugins/neural-composer` (create it if it doesn't exist).
+3. Copy the three downloaded files into that folder.
 4. In Obsidian: **Settings → Community plugins → Installed plugins**, find Neural Composer and toggle it on.
+
+[screenshot: Finder / Explorer showing the three files (main.js, manifest.json, styles.css) inside the .obsidian/plugins/neural-composer folder]
 
 ---
 
 ## Step 4 — First-run checklist
 
-After enabling the plugin, open **Settings → Neural Composer** and work through this list:
+After enabling the plugin, open **Settings → Neural Composer**. The panel opens with a sidebar of seven tabs.
+
+[screenshot: Neural Composer settings panel — full view showing the sidebar tabs on the left]
+
+Work through this checklist in order:
 
 - [ ] **Providers tab** — Enter at least one AI provider API key (or configure Ollama if you want a fully local setup).
 - [ ] **Models tab** — Select a chat model and an embedding model.
 - [ ] **Graph & Vault tab** — Paste the `lightrag-server` path from Step 2 into the **Command Path** field.
-- [ ] **Graph & Vault tab** — Choose a **Data Directory** where the graph files will be stored (can be anywhere on disk, does not need to be inside the vault).
-- [ ] **Graph & Vault tab** — Optionally set a **Watched Folder** to enable auto-sync.
+- [ ] **Graph & Vault tab** — Choose a **Data Directory** where graph files will be stored. This can be anywhere on disk — it does not need to be inside the vault. Use a dedicated, empty folder.
+- [ ] **Graph & Vault tab** — Optionally set a **Watched Folder** to enable auto-sync on save.
 - [ ] Toggle **Auto-start** to on.
 - [ ] Click **Restart Server** and wait for the status bar dot to turn green.
+
+[screenshot: status bar bottom-right showing a green dot next to "Neural Composer"]
+
 - [ ] Right-click a folder in the file explorer and choose **Add to graph** to ingest your first notes.
 
-If the status bar dot stays red, see the [Troubleshooting](Troubleshooting) page.
+[screenshot: right-click context menu on a vault folder showing the "Add to graph" option]
+
+If the status bar dot stays red after clicking Restart, see the [Troubleshooting](Troubleshooting) page.

--- a/wiki/MCP-Tools.md
+++ b/wiki/MCP-Tools.md
@@ -1,124 +1,154 @@
 # MCP Tools
 
-Neural Composer can expose your vault's knowledge graph to any client that supports the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). This lets external AI agents — Claude Desktop, Cursor, VS Code with Copilot, or custom scripts — query and reason over your graph without opening Obsidian.
+Neural Composer integrates with the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) as a **client**. This means you can connect external MCP servers to Neural Composer and use their tools directly from the chat pane — alongside your vault graph.
+
+> **Note:** Neural Composer connects *to* external MCP servers. It does not currently expose your vault as an MCP server to external clients such as Claude Desktop. The Tools (MCP) tab is for adding tools *into* Neural Composer's chat, not for exposing Neural Composer to other applications.
 
 ---
 
-## How it works
+## What you can do with MCP
 
-Neural Composer acts as an **MCP server**. It exposes tools that an MCP-compatible client can call:
+When an MCP server is connected, its tools appear in the chat pane alongside the built-in vault tools. The model can call them automatically when **Enable tools** is on (Settings → Chat).
 
-| Tool | What it does |
+Example use cases:
+
+| MCP server | What it adds to your chat |
 | :--- | :--- |
-| `query_graph` | Sends a question to LightRAG and returns the answer with citations. |
-| `list_documents` | Returns the list of ingested documents and their statuses. |
-| `get_entity` | Retrieves metadata and relationships for a named entity. |
+| `@modelcontextprotocol/server-github` | Read issues, PRs, and code from a GitHub repo |
+| `@modelcontextprotocol/server-filesystem` | Read and write files outside the vault |
+| `@modelcontextprotocol/server-brave-search` | Web search from within the chat |
+| Any custom MCP server | Whatever tools your server exposes |
 
-The client connects to Neural Composer, discovers these tools, and can invoke them as part of a conversation or automated workflow.
+[screenshot: chat pane — a tool call visible inline where the model called an MCP tool and shows its result before the final answer]
 
 ---
 
-## Step 1 — Enable the MCP server in Neural Composer
+## Adding an MCP server
 
 1. Open **Settings → Neural Composer → Tools (MCP)**.
 2. Click **Add MCP server**.
 3. Fill in the form:
-   - **Name:** anything you like (e.g., `Vault Graph`)
-   - **Transport:** `stdio` for local clients (Claude Desktop, Cursor); `sse` for network clients
-   - **Command:** the path to the Neural Composer MCP bridge (see below)
-4. Click **Save**.
+   - **Name:** a label for your reference (e.g., `GitHub`)
+   - **Parameters:** a JSON object describing how to launch the server
 
-[screenshot: filled-in "Add MCP server" form with Name "Vault Graph", Transport "stdio", and a command path]
+[screenshot: "Add MCP server" dialog with Name and Parameters fields]
 
----
+### Parameters format
 
-## Step 2 — Connect Claude Desktop
-
-Claude Desktop reads MCP server definitions from its config file.
-
-### Locate the config file
-
-| Platform | Path |
-| :--- | :--- |
-| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
-
-### Add the Neural Composer entry
-
-Open the file in any text editor and add an entry under `mcpServers`:
+The Parameters field expects a JSON object with this shape:
 
 ```json
 {
-  "mcpServers": {
-    "neural-composer": {
-      "command": "/path/to/neural-composer-mcp-bridge",
-      "args": [],
-      "env": {
-        "LIGHTRAG_URL": "http://localhost:9621"
-      }
-    }
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..."
   }
 }
 ```
 
-Replace `/path/to/neural-composer-mcp-bridge` with the command path shown in Neural Composer's settings.
+| Field | Required | Notes |
+| :--- | :--- | :--- |
+| `command` | Yes | The executable to run. Usually `npx` or `node`. |
+| `args` | No | Array of arguments passed to the command. |
+| `env` | No | Key/value pairs injected into the server's environment. |
 
-[screenshot: claude_desktop_config.json open in a text editor with the neural-composer entry visible]
+> **Important:** paste only this inner object into the Parameters field — do not wrap it in a `mcpServers` key or any other outer structure.
 
-### Restart Claude Desktop
-
-Quit and relaunch Claude Desktop. The Neural Composer tools will appear in the tool picker when you start a new conversation.
-
-[screenshot: Claude Desktop tool picker showing "neural-composer" as an available MCP server with its tools listed]
-
----
-
-## Step 3 — Test the connection
-
-In Claude Desktop (or your MCP client), start a conversation and ask:
-
-> "What topics are covered in my knowledge graph?"
-
-Claude should call `query_graph` and return an answer sourced from your vault.
-
-[screenshot: Claude Desktop conversation — user asks a question, Claude shows a tool call to query_graph, then the answer with citations]
+4. Click **Save**. Neural Composer launches the server as a subprocess and connects to it via stdio.
 
 ---
 
-## SSE transport (network clients)
+## Example: GitHub MCP server
 
-If you want to expose your graph to a remote client or a browser-based tool, use **SSE** transport instead of `stdio`.
+**Prerequisites:** Node.js installed; a GitHub personal access token with `repo` scope.
 
-1. In the Tools (MCP) tab, set Transport to `sse`.
-2. Neural Composer will expose an SSE endpoint at `http://localhost:<port>/sse`.
-3. Point your MCP client at that URL.
+Parameters:
 
-> **Security note:** SSE transport has no built-in authentication. Do not expose the SSE endpoint to the public internet without a reverse proxy and auth layer in front of it.
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_your_token_here"
+  }
+}
+```
+
+Once connected, you can ask questions in the chat like:
+- *"What are the open issues in my repo?"*
+- *"Summarize the last 5 commits."*
+
+The model will call the GitHub MCP tools automatically and combine the results with your vault graph.
+
+[screenshot: chat pane — a question about a GitHub repo, with a visible tool call to the GitHub MCP server and a combined answer]
 
 ---
 
-## Using MCP tools in the chat pane
+## Example: Filesystem MCP server
 
-When **Enable tools** is on in the Chat tab, the chat pane itself can call MCP tools registered in the Tools (MCP) tab. This means you can add external MCP servers (e.g., a web search tool or a calendar) and the chat model will use them alongside your vault graph.
+Allows the model to read files outside your Obsidian vault.
 
-[screenshot: chat pane with a tool call visible inline — the model invoked a registered MCP tool and shows the result before its final answer]
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/you/Documents"]
+}
+```
+
+Replace `/Users/you/Documents` with the directory you want to expose.
 
 ---
 
-## Troubleshooting MCP
+## Enabling and disabling tools per server
 
-### "No tools available" in Claude Desktop
+In the Tools (MCP) tab, each server has a toggle. When disabled, its tools are hidden from the model and will not be called.
 
-- Confirm the command path in `claude_desktop_config.json` is correct and the binary is executable.
-- Check that Neural Composer (and the LightRAG server) is running in Obsidian before opening Claude Desktop.
-- Try running the command manually in a terminal to see if it outputs errors.
+You can also configure individual tools per server — for example, to disable a destructive tool (like file deletion) while keeping read-only tools active.
 
-### Tool calls return empty results
+[screenshot: Tools (MCP) tab showing a server entry expanded with individual tool toggles visible]
 
-- The LightRAG server may be offline. Check the status bar dot in Obsidian.
-- Confirm `LIGHTRAG_URL` in the config matches the URL Neural Composer is listening on (default: `http://localhost:9621`).
+---
 
-### SSE client can't connect
+## MCP is desktop-only
 
-- Check that the port is not blocked by a firewall.
-- Verify the SSE endpoint URL in the client matches the one shown in the Neural Composer Tools (MCP) tab.
+MCP functionality is not available on mobile. The Tools (MCP) tab is hidden when Obsidian is running on iOS or Android.
+
+---
+
+## Troubleshooting
+
+### "No tools available" after adding a server
+
+- Confirm Node.js is installed and accessible (`node --version` in a terminal).
+- Try running the command manually in a terminal to see if it produces errors (e.g., `npx -y @modelcontextprotocol/server-github`).
+- Check that the API key or token in `env` is valid.
+
+### The server connects but no tool calls happen in chat
+
+- Confirm **Enable tools** is toggled on in the Chat settings tab.
+- Check that **Max auto-iterations** is at least `1` (Settings → Chat).
+
+### "Invalid JSON format" error in the Add MCP server dialog
+
+Paste only the inner object into the Parameters field. The correct format is:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..." }
+}
+```
+
+Not this:
+
+```json
+{
+  "mcpServers": {
+    "my-server": { ... }
+  }
+}
+```
+
+The `mcpServers` wrapper is Claude Desktop's config format — it is not used here.

--- a/wiki/MCP-Tools.md
+++ b/wiki/MCP-Tools.md
@@ -1,0 +1,124 @@
+# MCP Tools
+
+Neural Composer can expose your vault's knowledge graph to any client that supports the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). This lets external AI agents — Claude Desktop, Cursor, VS Code with Copilot, or custom scripts — query and reason over your graph without opening Obsidian.
+
+---
+
+## How it works
+
+Neural Composer acts as an **MCP server**. It exposes tools that an MCP-compatible client can call:
+
+| Tool | What it does |
+| :--- | :--- |
+| `query_graph` | Sends a question to LightRAG and returns the answer with citations. |
+| `list_documents` | Returns the list of ingested documents and their statuses. |
+| `get_entity` | Retrieves metadata and relationships for a named entity. |
+
+The client connects to Neural Composer, discovers these tools, and can invoke them as part of a conversation or automated workflow.
+
+---
+
+## Step 1 — Enable the MCP server in Neural Composer
+
+1. Open **Settings → Neural Composer → Tools (MCP)**.
+2. Click **Add MCP server**.
+3. Fill in the form:
+   - **Name:** anything you like (e.g., `Vault Graph`)
+   - **Transport:** `stdio` for local clients (Claude Desktop, Cursor); `sse` for network clients
+   - **Command:** the path to the Neural Composer MCP bridge (see below)
+4. Click **Save**.
+
+[screenshot: filled-in "Add MCP server" form with Name "Vault Graph", Transport "stdio", and a command path]
+
+---
+
+## Step 2 — Connect Claude Desktop
+
+Claude Desktop reads MCP server definitions from its config file.
+
+### Locate the config file
+
+| Platform | Path |
+| :--- | :--- |
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+### Add the Neural Composer entry
+
+Open the file in any text editor and add an entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "neural-composer": {
+      "command": "/path/to/neural-composer-mcp-bridge",
+      "args": [],
+      "env": {
+        "LIGHTRAG_URL": "http://localhost:9621"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/neural-composer-mcp-bridge` with the command path shown in Neural Composer's settings.
+
+[screenshot: claude_desktop_config.json open in a text editor with the neural-composer entry visible]
+
+### Restart Claude Desktop
+
+Quit and relaunch Claude Desktop. The Neural Composer tools will appear in the tool picker when you start a new conversation.
+
+[screenshot: Claude Desktop tool picker showing "neural-composer" as an available MCP server with its tools listed]
+
+---
+
+## Step 3 — Test the connection
+
+In Claude Desktop (or your MCP client), start a conversation and ask:
+
+> "What topics are covered in my knowledge graph?"
+
+Claude should call `query_graph` and return an answer sourced from your vault.
+
+[screenshot: Claude Desktop conversation — user asks a question, Claude shows a tool call to query_graph, then the answer with citations]
+
+---
+
+## SSE transport (network clients)
+
+If you want to expose your graph to a remote client or a browser-based tool, use **SSE** transport instead of `stdio`.
+
+1. In the Tools (MCP) tab, set Transport to `sse`.
+2. Neural Composer will expose an SSE endpoint at `http://localhost:<port>/sse`.
+3. Point your MCP client at that URL.
+
+> **Security note:** SSE transport has no built-in authentication. Do not expose the SSE endpoint to the public internet without a reverse proxy and auth layer in front of it.
+
+---
+
+## Using MCP tools in the chat pane
+
+When **Enable tools** is on in the Chat tab, the chat pane itself can call MCP tools registered in the Tools (MCP) tab. This means you can add external MCP servers (e.g., a web search tool or a calendar) and the chat model will use them alongside your vault graph.
+
+[screenshot: chat pane with a tool call visible inline — the model invoked a registered MCP tool and shows the result before its final answer]
+
+---
+
+## Troubleshooting MCP
+
+### "No tools available" in Claude Desktop
+
+- Confirm the command path in `claude_desktop_config.json` is correct and the binary is executable.
+- Check that Neural Composer (and the LightRAG server) is running in Obsidian before opening Claude Desktop.
+- Try running the command manually in a terminal to see if it outputs errors.
+
+### Tool calls return empty results
+
+- The LightRAG server may be offline. Check the status bar dot in Obsidian.
+- Confirm `LIGHTRAG_URL` in the config matches the URL Neural Composer is listening on (default: `http://localhost:9621`).
+
+### SSE client can't connect
+
+- Check that the port is not blocked by a firewall.
+- Verify the SSE endpoint URL in the client matches the one shown in the Neural Composer Tools (MCP) tab.

--- a/wiki/Providers-Guide.md
+++ b/wiki/Providers-Guide.md
@@ -96,17 +96,38 @@ There is an additional API-level difference: `gemini-embedding-001` accepts a `t
 
 #### Migration strategy (gemini-embedding-001 → gemini-embedding-2)
 
-Google's recommended approach for production systems is a **shadow index**:
+Choose an approach based on the size of your vault:
 
-1. Keep your existing vault running normally on `gemini-embedding-001` (works until July 14, 2026).
-2. Create a new, empty LightRAG data directory.
-3. Configure Neural Composer to point at the new directory with `gemini-embedding-2` as the embedding model.
-4. Re-ingest all your notes into the new directory (run overnight for large vaults).
-5. Validate the new index with a set of representative queries before switching.
-6. Once satisfied, update the **Data Directory** path in settings to the new directory and click **Restart Server**.
-7. Delete the old data directory.
+---
 
-> **Tip:** Use the **Batch Embedding API** option in LightRAG's `.env` if available — Google prices batch embeddings at 50% of the standard per-call rate, significantly reducing the cost of a full re-ingestion.
+**Option A — Simple migration (small vaults, < ~500 notes)**
+
+If re-ingesting takes less than an hour and you can afford a short downtime, this is the quickest path:
+
+1. In Settings → Graph & Vault, change the **Embedding model (server-side)** to `gemini-embedding-2`.
+2. Click **Restart Server**.
+3. Right-click your watched folder → **Add to graph** to re-ingest everything.
+4. Wait for all status dots to turn 🟢.
+
+The graph is unavailable for queries while re-ingestion is in progress. For a small vault this is a minor inconvenience.
+
+---
+
+**Option B — Shadow index (large vaults, or if you need zero downtime)**
+
+Build the new index in a separate directory while your existing vault keeps working normally. Only switch over once the new index is fully built and validated.
+
+1. Create a new, empty folder anywhere on your disk (e.g., `lightrag-data-v2`).
+2. In Settings → Graph & Vault, change **Data Directory** to the new folder and set **Embedding model** to `gemini-embedding-2`.
+3. Click **Restart Server** — LightRAG now points at the empty new directory.
+4. Re-ingest all your notes (right-click watched folder → **Add to graph**). Run overnight for large vaults.
+5. Test the new index with a few representative queries to confirm quality.
+6. Once satisfied, the migration is complete — the new directory is now your active index.
+7. Delete the old data directory when you no longer need it as a fallback.
+
+The key benefit: if anything goes wrong during steps 2–5 (API error, power cut, poor result quality), you can simply point **Data Directory** back at the original folder and continue using the old index until you're ready to try again.
+
+> **Cost tip:** Google prices batch embeddings at 50% of the standard per-call rate. If LightRAG's `.env` exposes a batch embedding option, enabling it before re-ingestion can meaningfully reduce the API cost of a large rebuild.
 
 ### Notes
 

--- a/wiki/Providers-Guide.md
+++ b/wiki/Providers-Guide.md
@@ -1,0 +1,212 @@
+# Providers Guide
+
+This page covers provider-specific setup, recommended models, and known quirks for each AI provider supported by Neural Composer.
+
+Each provider needs two things: a configuration entry in **Settings → Providers**, and a model selection in **Settings → Models** (for the chat model) and/or **Settings → Graph & Vault** (for the graph logic model and embedding model).
+
+---
+
+## OpenAI
+
+**Get an API key:** [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+
+### Recommended models
+
+| Use | Model | Notes |
+| :--- | :--- | :--- |
+| Chat | `gpt-4o` | Best quality; good for complex reasoning questions |
+| Chat (fast) | `gpt-4o-mini` | Much cheaper; good for simple questions |
+| Graph logic | `gpt-4o-mini` | Cost-efficient for entity extraction during ingestion |
+| Embedding | `text-embedding-3-small` | Good balance of quality and cost |
+| Embedding (best) | `text-embedding-3-large` | Better recall on large, diverse vaults |
+
+### Notes
+
+- The **Apply model** slot (used for note edits) works well with `gpt-4o-mini`.
+- OpenAI rate limits apply to both chat and embedding calls. If ingestion fails with `429 Too Many Requests`, reduce **Async workers** in Advanced settings.
+
+[screenshot: Providers tab with an OpenAI row showing a masked API key]
+
+---
+
+## Anthropic
+
+**Get an API key:** [console.anthropic.com](https://console.anthropic.com)
+
+### Recommended models
+
+| Use | Model | Notes |
+| :--- | :--- | :--- |
+| Chat | `claude-sonnet-4-5` | Strong reasoning, long context window |
+| Chat (fast) | `claude-haiku-4-5` | Fastest Claude model; good for quick queries |
+| Graph logic | `claude-haiku-4-5` | Fast and cheap for extraction tasks |
+
+> **Note:** Anthropic does not offer an embedding model. For embeddings with Anthropic as your chat provider, use OpenAI's `text-embedding-3-small` or Ollama's `nomic-embed-text` as a separate embedding provider.
+
+---
+
+## Gemini (Google)
+
+**Get an API key:** [aistudio.google.com](https://aistudio.google.com)
+
+### Recommended models
+
+| Use | Model | Notes |
+| :--- | :--- | :--- |
+| Chat | `gemini-1.5-pro` | Strong on long-context retrieval |
+| Chat (fast) | `gemini-1.5-flash` | Very cost-efficient |
+| Graph logic | `gemini-1.5-flash` | Excellent cost-to-quality for extraction |
+| Embedding | `text-embedding-004` | Google's latest embedding model |
+
+### Notes
+
+- Gemini Flash is one of the most cost-efficient options for the **graph logic model** — it's called for every chunk during ingestion, so cost adds up quickly on large vaults.
+- The Gemini free tier is generous for testing, but has strict rate limits. Switch to a paid key for production ingestion.
+
+---
+
+## Groq
+
+**Get an API key:** [console.groq.com](https://console.groq.com)
+
+### Recommended models
+
+| Use | Model | Notes |
+| :--- | :--- | :--- |
+| Chat | `llama-3.3-70b-versatile` | Fast inference, strong general quality |
+| Chat (fast) | `llama-3.1-8b-instant` | Extremely fast; good for simple queries |
+| Graph logic | `llama-3.1-8b-instant` | Very cheap; fast ingestion |
+
+### Notes
+
+- Groq does not offer an embedding model. Pair it with OpenAI or Ollama embeddings.
+- Groq's rate limits on the free tier are low (tokens per minute). For large vault ingestion, use a paid plan or reduce **Async workers**.
+
+---
+
+## OpenRouter
+
+**Get an API key:** [openrouter.ai/keys](https://openrouter.ai/keys)
+
+OpenRouter is a unified API gateway to dozens of providers. Useful when you want to mix models or access models not directly supported.
+
+### Setup
+
+- Provider: `OpenRouter`
+- API key: your OpenRouter key
+- Model ID: the full OpenRouter model identifier, e.g., `anthropic/claude-3.5-sonnet`, `google/gemini-flash-1.5`, `meta-llama/llama-3.3-70b-instruct`
+
+### Notes
+
+- Model IDs on OpenRouter use the format `provider/model-name`. Check [openrouter.ai/models](https://openrouter.ai/models) for the exact string.
+- Billing goes through your OpenRouter account and is charged per-token by the underlying provider's rate.
+
+---
+
+## Deepseek
+
+**Get an API key:** [platform.deepseek.com](https://platform.deepseek.com)
+
+### Recommended models
+
+| Use | Model | Notes |
+| :--- | :--- | :--- |
+| Chat | `deepseek-chat` | Strong reasoning; very competitive cost |
+| Chat (reasoning) | `deepseek-reasoner` | Chain-of-thought model for complex questions |
+| Graph logic | `deepseek-chat` | Affordable for extraction tasks |
+
+### Notes
+
+- Deepseek does not offer an embedding model. Use OpenAI or Ollama embeddings.
+- The Deepseek API is compatible with the OpenAI SDK format, so it works reliably with Neural Composer's OpenAI-compatible path.
+
+---
+
+## Ollama (fully local)
+
+**Install Ollama:** [ollama.com](https://ollama.com)
+
+Ollama runs open-weight models entirely on your local machine. No API key, no data leaving your machine.
+
+### Setup
+
+1. Install Ollama and start the service (`ollama serve`).
+2. Pull the models you want:
+   ```bash
+   ollama pull llama3.2          # chat model
+   ollama pull nomic-embed-text   # embedding model
+   ```
+3. In Providers, set host to `http://localhost:11434` (default). No API key needed.
+4. In Models, select your pulled models.
+
+[screenshot: Providers tab showing Ollama row with host URL and no API key]
+
+### Recommended models
+
+| Use | Model | Notes |
+| :--- | :--- | :--- |
+| Chat | `llama3.2` / `mistral` | Good general-purpose; fits on 8 GB VRAM |
+| Chat (large) | `llama3.1:70b` | Much better quality; needs 40+ GB RAM |
+| Graph logic | `llama3.2` | Fast and free; extraction quality is adequate |
+| Embedding | `nomic-embed-text` | Best local embedding model; 768-dimensional |
+
+### Notes
+
+- The first request after Ollama starts takes 10–60 seconds while the model loads. Subsequent requests are fast.
+- Ingestion is significantly slower with local models vs. cloud APIs, especially on CPU-only machines.
+- If Ollama is running on a different machine than Obsidian, set the host to that machine's IP (e.g., `http://192.168.1.50:11434`) and ensure the port is accessible.
+
+---
+
+## LM Studio
+
+**Install LM Studio:** [lmstudio.ai](https://lmstudio.ai)
+
+LM Studio provides a GUI for managing local models and exposes an OpenAI-compatible API.
+
+### Setup
+
+1. Download and load a model in LM Studio.
+2. Start the local server (default port: `1234`).
+3. In Providers, set host to `http://localhost:1234`. No API key needed.
+4. In Models, type the model name exactly as shown in LM Studio's server log.
+
+### Notes
+
+- LM Studio's API is OpenAI-compatible, so any model ID that works in LM Studio's UI should work here.
+- LM Studio does not expose an embedding endpoint by default. Use Ollama or OpenAI for embeddings.
+
+---
+
+## Morph
+
+Morph is a code-specialized model designed for the **Apply** step — when Neural Composer edits a note in response to a chat suggestion.
+
+**Get an API key:** [morph.so](https://morph.so)
+
+Set Morph as the **Apply model** in Settings → Models. Keep your primary chat model unchanged.
+
+---
+
+## Perplexity
+
+**Get an API key:** [perplexity.ai/settings/api](https://perplexity.ai/settings/api)
+
+Perplexity's models include web search augmentation. Useful as a **chat model** when you want answers that combine your vault with up-to-date web information.
+
+> **Note:** Perplexity's search-augmented models are not well-suited as the **graph logic model** — use a standard LLM (OpenAI, Gemini) for entity extraction.
+
+---
+
+## Mistral
+
+**Get an API key:** [console.mistral.ai](https://console.mistral.ai)
+
+### Recommended models
+
+| Use | Model | Notes |
+| :--- | :--- | :--- |
+| Chat | `mistral-large-latest` | Strong reasoning |
+| Chat (fast) | `mistral-small-latest` | Fast and affordable |
+| Embedding | `mistral-embed` | Mistral's dedicated embedding model |
+| Graph logic | `mistral-small-latest` | Cost-efficient for extraction |

--- a/wiki/Providers-Guide.md
+++ b/wiki/Providers-Guide.md
@@ -4,6 +4,8 @@ This page covers provider-specific setup, recommended models, and known quirks f
 
 Each provider needs two things: a configuration entry in **Settings → Providers**, and a model selection in **Settings → Models** (for the chat model) and/or **Settings → Graph & Vault** (for the graph logic model and embedding model).
 
+> **Last verified:** May 2026. Model availability changes frequently — check the provider's official documentation if a model ID returns a 404 or 401.
+
 ---
 
 ## OpenAI
@@ -12,18 +14,21 @@ Each provider needs two things: a configuration entry in **Settings → Provider
 
 ### Recommended models
 
-| Use | Model | Notes |
+| Use | Model ID | Notes |
 | :--- | :--- | :--- |
-| Chat | `gpt-4o` | Best quality; good for complex reasoning questions |
-| Chat (fast) | `gpt-4o-mini` | Much cheaper; good for simple questions |
-| Graph logic | `gpt-4o-mini` | Cost-efficient for entity extraction during ingestion |
-| Embedding | `text-embedding-3-small` | Good balance of quality and cost |
-| Embedding (best) | `text-embedding-3-large` | Better recall on large, diverse vaults |
+| Chat (quality) | `gpt-5.5-2026-04-23` | Current flagship as of April 2026 |
+| Chat (quality, reasoning) | `o3` | Best for complex multi-hop questions |
+| Chat (fast/cheap) | `gpt-4.1-mini` | Alias for `gpt-4.1-mini-2025-04-14`; great quality/cost ratio |
+| Graph logic | `gpt-4.1-nano` | Cheapest option; sufficient for entity extraction |
+| Embedding | `text-embedding-3-small` | $0.02/M tokens — good balance of quality and cost |
+| Embedding (best) | `text-embedding-3-large` | $0.13/M tokens — better recall on large, diverse vaults |
 
 ### Notes
 
-- The **Apply model** slot (used for note edits) works well with `gpt-4o-mini`.
-- OpenAI rate limits apply to both chat and embedding calls. If ingestion fails with `429 Too Many Requests`, reduce **Async workers** in Advanced settings.
+- `gpt-4o` is still available in the API but **retiring October 1, 2026**. Prefer `gpt-4.1-mini` for equivalent cost-efficient tasks.
+- The `chatgpt-4o-latest` alias was removed from the API on February 17, 2026.
+- `text-embedding-ada-002` is legacy; `text-embedding-3-small` is the drop-in replacement.
+- No free API tier — pay-as-you-go with rate limit tiers.
 
 [screenshot: Providers tab with an OpenAI row showing a masked API key]
 
@@ -35,13 +40,18 @@ Each provider needs two things: a configuration entry in **Settings → Provider
 
 ### Recommended models
 
-| Use | Model | Notes |
+| Use | Model ID | Notes |
 | :--- | :--- | :--- |
-| Chat | `claude-sonnet-4-5` | Strong reasoning, long context window |
-| Chat (fast) | `claude-haiku-4-5` | Fastest Claude model; good for quick queries |
-| Graph logic | `claude-haiku-4-5` | Fast and cheap for extraction tasks |
+| Chat (quality) | `claude-opus-4-7` | Current flagship; strong reasoning, 1M token context |
+| Chat (fast/cheap) | `claude-haiku-4-5-20251001` | Fastest Claude model; ideal for quick queries |
+| Graph logic | `claude-haiku-4-5-20251001` | Fast and cheap for extraction tasks |
 
-> **Note:** Anthropic does not offer an embedding model. For embeddings with Anthropic as your chat provider, use OpenAI's `text-embedding-3-small` or Ollama's `nomic-embed-text` as a separate embedding provider.
+### Notes
+
+- **Use full versioned IDs in production.** Starting with the 4.6 generation, dateless aliases like `claude-sonnet-4-6` are pinned snapshots, not rolling aliases. Both forms work; versioned IDs are safer.
+- `claude-sonnet-4-20250514` and `claude-opus-4-20250514` are **deprecated and retire June 15, 2026**. Do not use these.
+- Anthropic does **not** offer an embedding model. For embeddings, pair Anthropic with OpenAI's `text-embedding-3-small` or Ollama's `nomic-embed-text` configured as a separate embedding provider.
+- No free API tier.
 
 ---
 
@@ -49,19 +59,22 @@ Each provider needs two things: a configuration entry in **Settings → Provider
 
 **Get an API key:** [aistudio.google.com](https://aistudio.google.com)
 
+> ⚠️ **Important:** Gemini 1.5 models (`gemini-1.5-pro`, `gemini-1.5-flash`) are **completely shut down** and return 404. `text-embedding-004` was shut down on **January 14, 2026**. If you were using these, migrate immediately.
+
 ### Recommended models
 
-| Use | Model | Notes |
+| Use | Model ID | Notes |
 | :--- | :--- | :--- |
-| Chat | `gemini-1.5-pro` | Strong on long-context retrieval |
-| Chat (fast) | `gemini-1.5-flash` | Very cost-efficient |
-| Graph logic | `gemini-1.5-flash` | Excellent cost-to-quality for extraction |
-| Embedding | `text-embedding-004` | Google's latest embedding model |
+| Chat (quality) | `gemini-2.5-pro` | State-of-the-art; best for complex reasoning |
+| Chat (fast/cheap) | `gemini-2.5-flash` | Best balance of speed and quality |
+| Graph logic | `gemini-2.5-flash-lite` | Most cost-efficient option; high throughput |
+| Embedding | `gemini-embedding-2` | GA since April 23, 2026; replaces `text-embedding-004`; 3,072 dimensions |
 
 ### Notes
 
-- Gemini Flash is one of the most cost-efficient options for the **graph logic model** — it's called for every chunk during ingestion, so cost adds up quickly on large vaults.
-- The Gemini free tier is generous for testing, but has strict rate limits. Switch to a paid key for production ingestion.
+- **`gemini-2.0-flash`** was retired March 3, 2026. Do not use.
+- The free tier (no credit card required) allows: `gemini-2.5-flash` at 10 RPM / 250 RPD / 250k TPM; `gemini-2.5-pro` at 5 RPM / 100 RPD. Quotas were reduced ~50–80% in December 2025 — switch to a paid key for ingestion workloads.
+- `gemini-2.5-flash-lite` is the best choice for the **graph logic model** — it's called for every chunk during ingestion, so cost compounds quickly on large vaults.
 
 ---
 
@@ -71,16 +84,19 @@ Each provider needs two things: a configuration entry in **Settings → Provider
 
 ### Recommended models
 
-| Use | Model | Notes |
+| Use | Model ID | Notes |
 | :--- | :--- | :--- |
-| Chat | `llama-3.3-70b-versatile` | Fast inference, strong general quality |
-| Chat (fast) | `llama-3.1-8b-instant` | Extremely fast; good for simple queries |
-| Graph logic | `llama-3.1-8b-instant` | Very cheap; fast ingestion |
+| Chat (quality) | `openai/gpt-oss-120b` | 120B MoE open-weight; replaced llama-4-maverick |
+| Chat (quality, alt) | `llama-3.3-70b-versatile` | Still available; strong text-only option |
+| Chat (fast/cheap) | `llama-3.1-8b-instant` | Extremely fast; good for simple queries |
+| Graph logic | `llama-3.1-8b-instant` | Very cheap; adequate for extraction |
 
 ### Notes
 
-- Groq does not offer an embedding model. Pair it with OpenAI or Ollama embeddings.
-- Groq's rate limits on the free tier are low (tokens per minute). For large vault ingestion, use a paid plan or reduce **Async workers**.
+- `meta-llama/llama-4-maverick-17b-128e-instruct` was **deprecated February 20, 2026**; use `openai/gpt-oss-120b` instead.
+- Groq does **not** offer an embedding endpoint. Pair with OpenAI or Ollama for embeddings.
+- Free tier (no credit card): `llama-3.1-8b-instant` up to ~14,400 RPD; `llama-3.3-70b-versatile` at ~30 RPM / ~1k RPD. Sufficient for personal vault use.
+- For a current model list: `GET https://api.groq.com/openai/v1/models`
 
 ---
 
@@ -94,31 +110,36 @@ OpenRouter is a unified API gateway to dozens of providers. Useful when you want
 
 - Provider: `OpenRouter`
 - API key: your OpenRouter key
-- Model ID: the full OpenRouter model identifier, e.g., `anthropic/claude-3.5-sonnet`, `google/gemini-flash-1.5`, `meta-llama/llama-3.3-70b-instruct`
+- Model ID: the full OpenRouter identifier, e.g., `anthropic/claude-opus-4`, `google/gemini-2.5-pro`, `meta-llama/llama-3.3-70b-instruct`
 
 ### Notes
 
-- Model IDs on OpenRouter use the format `provider/model-name`. Check [openrouter.ai/models](https://openrouter.ai/models) for the exact string.
-- Billing goes through your OpenRouter account and is charged per-token by the underlying provider's rate.
+- Model IDs use the format `provider/model-name`. Check [openrouter.ai/models](https://openrouter.ai/models) for the exact string.
+- Billing goes through your OpenRouter account at the underlying provider's rate.
+- Useful for accessing Gemini 2.5 Pro or Claude Opus without separate accounts.
 
 ---
 
-## Deepseek
+## DeepSeek
 
 **Get an API key:** [platform.deepseek.com](https://platform.deepseek.com)
 
+> ⚠️ **Migration required:** `deepseek-chat` and `deepseek-reasoner` are **deprecated and retire July 24, 2026**. Migrate to the IDs below.
+
 ### Recommended models
 
-| Use | Model | Notes |
+| Use | Model ID | Notes |
 | :--- | :--- | :--- |
-| Chat | `deepseek-chat` | Strong reasoning; very competitive cost |
-| Chat (reasoning) | `deepseek-reasoner` | Chain-of-thought model for complex questions |
-| Graph logic | `deepseek-chat` | Affordable for extraction tasks |
+| Chat (quality) | `deepseek-v4-pro` | Complex reasoning, coding, agents; 1M context |
+| Chat (fast/cheap) | `deepseek-v4-flash` | Fast, cost-efficient; non-thinking mode |
+| Graph logic | `deepseek-v4-flash` | ~$0.28/M output tokens |
 
 ### Notes
 
-- Deepseek does not offer an embedding model. Use OpenAI or Ollama embeddings.
-- The Deepseek API is compatible with the OpenAI SDK format, so it works reliably with Neural Composer's OpenAI-compatible path.
+- The legacy aliases `deepseek-chat` → `deepseek-v4-flash` (non-thinking) and `deepseek-reasoner` → `deepseek-v4-flash` (thinking) still route correctly today, but **will stop working July 24, 2026**.
+- DeepSeek does **not** offer an embedding model. Use OpenAI or Ollama embeddings.
+- New accounts receive 5M free tokens.
+- DeepSeek's API uses the OpenAI-compatible format.
 
 ---
 
@@ -133,28 +154,30 @@ Ollama runs open-weight models entirely on your local machine. No API key, no da
 1. Install Ollama and start the service (`ollama serve`).
 2. Pull the models you want:
    ```bash
-   ollama pull llama3.2          # chat model
-   ollama pull nomic-embed-text   # embedding model
+   ollama pull llama3.3          # chat model (70B, recommended)
+   ollama pull llama3.1          # chat model (8B, lightweight alternative)
+   ollama pull nomic-embed-text  # embedding model
    ```
-3. In Providers, set host to `http://localhost:11434` (default). No API key needed.
+3. In Providers, set host to `http://localhost:11434`. No API key needed.
 4. In Models, select your pulled models.
 
 [screenshot: Providers tab showing Ollama row with host URL and no API key]
 
 ### Recommended models
 
-| Use | Model | Notes |
+| Use | Pull name | Notes |
 | :--- | :--- | :--- |
-| Chat | `llama3.2` / `mistral` | Good general-purpose; fits on 8 GB VRAM |
-| Chat (large) | `llama3.1:70b` | Much better quality; needs 40+ GB RAM |
-| Graph logic | `llama3.2` | Fast and free; extraction quality is adequate |
-| Embedding | `nomic-embed-text` | Best local embedding model; 768-dimensional |
+| Chat (quality) | `llama3.3` | 70B; rivals Llama 3.1 405B; needs ~40 GB RAM |
+| Chat (fast/cheap) | `llama3.1` | 8B version; solid default; runs on 8 GB VRAM |
+| Chat (edge/mobile) | `llama3.2` | 1B and 3B sizes |
+| Embedding | `nomic-embed-text` | 274 MB; 8192-token context; 768 dims; outperforms `text-embedding-3-small` on most benchmarks |
+| Embedding (alt) | `mxbai-embed-large` | 1024 dims; SOTA for BERT-large class |
 
 ### Notes
 
-- The first request after Ollama starts takes 10–60 seconds while the model loads. Subsequent requests are fast.
-- Ingestion is significantly slower with local models vs. cloud APIs, especially on CPU-only machines.
-- If Ollama is running on a different machine than Obsidian, set the host to that machine's IP (e.g., `http://192.168.1.50:11434`) and ensure the port is accessible.
+- The first request after Ollama starts takes 10–60 seconds while the model loads into memory. Subsequent requests are fast.
+- If Ollama is on a different machine, set the host to that machine's IP (e.g., `http://192.168.1.50:11434`) and ensure port 11434 is accessible.
+- Ingestion is significantly slower with local models vs. cloud APIs on CPU-only machines.
 
 ---
 
@@ -162,7 +185,7 @@ Ollama runs open-weight models entirely on your local machine. No API key, no da
 
 **Install LM Studio:** [lmstudio.ai](https://lmstudio.ai)
 
-LM Studio provides a GUI for managing local models and exposes an OpenAI-compatible API.
+LM Studio provides a GUI for downloading and running quantized (GGUF) models locally, with an OpenAI-compatible API.
 
 ### Setup
 
@@ -173,18 +196,31 @@ LM Studio provides a GUI for managing local models and exposes an OpenAI-compati
 
 ### Notes
 
-- LM Studio's API is OpenAI-compatible, so any model ID that works in LM Studio's UI should work here.
-- LM Studio does not expose an embedding endpoint by default. Use Ollama or OpenAI for embeddings.
+- **Critical limitation:** LM Studio cannot serve chat completions and embeddings simultaneously from the same instance. To use LM Studio for both, run two separate LM Studio instances on different ports.
+- LM Studio supports `nomic-embed-text-v1.5` (GGUF) as an embedding model — load it from the Discover tab.
+- Any GGUF-format chat model from HuggingFace works for graph logic. Use structured output mode for better entity extraction.
 
 ---
 
 ## Morph
 
-Morph is a code-specialized model designed for the **Apply** step — when Neural Composer edits a note in response to a chat suggestion.
+Morph is a code-editing subagent specialized for the **Apply** step — when Neural Composer merges a suggested edit back into a note. It uses a custom 7B model optimized for fast, accurate file diffing.
 
-**Get an API key:** [morph.so](https://morph.so)
+**Get an API key:** [morphllm.com](https://morphllm.com)
 
-Set Morph as the **Apply model** in Settings → Models. Keep your primary chat model unchanged.
+### Models
+
+| Model ID | Speed | Accuracy | Context | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| `morph-v3-fast` | ~10,500 tok/s | 96% | 82k | Best for most apply operations |
+| `morph-v3-large` | ~5,000 tok/s | 98% | 262k | Use for long files or complex edits |
+| `auto` | — | — | — | Routes between fast and large automatically |
+
+### Notes
+
+- Set Morph as the **Apply model** in Settings → Models. Keep your primary chat model unchanged.
+- Base URL: `https://api.morphllm.com/v1`
+- Morph does **not** offer chat, embeddings, or entity extraction — it is specialized for code/text apply operations only.
 
 ---
 
@@ -192,9 +228,24 @@ Set Morph as the **Apply model** in Settings → Models. Keep your primary chat 
 
 **Get an API key:** [perplexity.ai/settings/api](https://perplexity.ai/settings/api)
 
-Perplexity's models include web search augmentation. Useful as a **chat model** when you want answers that combine your vault with up-to-date web information.
+Perplexity's models augment responses with real-time web search. Useful when you want answers that combine your vault with current information.
 
-> **Note:** Perplexity's search-augmented models are not well-suited as the **graph logic model** — use a standard LLM (OpenAI, Gemini) for entity extraction.
+### Recommended models
+
+| Use | Model ID | Notes |
+| :--- | :--- | :--- |
+| Chat (quality) | `sonar-pro` | Deeper retrieval; 2× more search results |
+| Chat (reasoning) | `sonar-reasoning-pro` | Chain-of-thought + live web search |
+| Chat (fast/cheap) | `sonar` | Lightweight; grounded; fast |
+| Research | `sonar-deep-research` | Exhaustive multi-step research; hundreds of sources |
+
+### Notes
+
+- The old `sonar-reasoning` ID was **deprecated December 15, 2025**. Migrate to `sonar-reasoning-pro`.
+- All `llama-3.1-sonar-*` and `pplx-*` model IDs are deprecated — use only the `sonar*` family.
+- Perplexity does **not** offer an embedding model.
+- **No permanent free tier** for the API. New accounts receive $25–$50 in trial credits. Pro subscribers get $5/month in API credits.
+- Perplexity models are not well-suited as the **graph logic model** — the web search context adds noise and cost during entity extraction. Use a standard LLM (OpenAI, Gemini) for that role.
 
 ---
 
@@ -204,9 +255,16 @@ Perplexity's models include web search augmentation. Useful as a **chat model** 
 
 ### Recommended models
 
-| Use | Model | Notes |
+| Use | Model ID | Notes |
 | :--- | :--- | :--- |
-| Chat | `mistral-large-latest` | Strong reasoning |
-| Chat (fast) | `mistral-small-latest` | Fast and affordable |
-| Embedding | `mistral-embed` | Mistral's dedicated embedding model |
-| Graph logic | `mistral-small-latest` | Cost-efficient for extraction |
+| Chat (quality) | `mistral-large-latest` | 675B total / 41B active MoE; strong reasoning |
+| Chat (fast/cheap) | `mistral-small-latest` | Mistral Small 4 (March 2026); merged reasoning + vision + coding |
+| Embedding | `mistral-embed` | 1024-dim text embeddings |
+| Embedding (code) | `codestral-embed-2505` | Code-specific embeddings; May 2025 |
+| Graph logic | `mistral-small-latest` | Cost-efficient for extraction tasks |
+
+### Notes
+
+- `mistral-large-latest` always points to the most recent large model. Use the versioned ID (`mistral-large-2512`) for production stability.
+- Free "Experiment" plan: 1B tokens/month, all models, no credit card (phone verification required).
+- Prompt caching available at 10% of standard input price — useful when re-running queries against the same vault context.

--- a/wiki/Providers-Guide.md
+++ b/wiki/Providers-Guide.md
@@ -59,22 +59,59 @@ Each provider needs two things: a configuration entry in **Settings → Provider
 
 **Get an API key:** [aistudio.google.com](https://aistudio.google.com)
 
-> ⚠️ **Important:** Gemini 1.5 models (`gemini-1.5-pro`, `gemini-1.5-flash`) are **completely shut down** and return 404. `text-embedding-004` was shut down on **January 14, 2026**. If you were using these, migrate immediately.
+> ⚠️ **Shut-down alerts:**
+> - Gemini 1.5 models (`gemini-1.5-pro`, `gemini-1.5-flash`) are **completely shut down** and return 404.
+> - `text-embedding-004` was shut down **January 14, 2026**.
+> - `gemini-embedding-001` shuts down **July 14, 2026** (~7 weeks from the date of this writing).
+> - `gemini-2.0-flash` was retired March 3, 2026.
 
-### Recommended models
+### Recommended models — chat
 
 | Use | Model ID | Notes |
 | :--- | :--- | :--- |
 | Chat (quality) | `gemini-2.5-pro` | State-of-the-art; best for complex reasoning |
 | Chat (fast/cheap) | `gemini-2.5-flash` | Best balance of speed and quality |
 | Graph logic | `gemini-2.5-flash-lite` | Most cost-efficient option; high throughput |
-| Embedding | `gemini-embedding-2` | GA since April 23, 2026; replaces `text-embedding-004`; 3,072 dimensions |
+
+### Embedding models — read this before choosing
+
+The embedding situation for Gemini users requires a deliberate choice. **Do not switch embedding models mid-project without planning a full re-ingestion.**
+
+| Model | Dimensions | Status | Notes |
+| :--- | :--- | :--- | :--- |
+| `gemini-embedding-001` | 3072 (default) | ⚠️ Active until **Jul 14, 2026** | GA since July 2025; supports `task_type` parameter |
+| `gemini-embedding-2` | 3072 (default) | ✅ GA since Apr 23, 2026 | Multimodal; does NOT support `task_type` |
+
+**If you are starting a new vault from scratch:** use `gemini-embedding-2`.
+
+**If you already have an indexed vault using `gemini-embedding-001`:** you must migrate before July 14, 2026, but do not rush — a full re-ingestion of all your notes is required. See the migration notes below.
+
+#### Why switching requires a full rebuild
+
+Even though both models output 3072-dimensional vectors, they live in **completely different vector spaces**. Cosine similarity scores computed between a vector from `gemini-embedding-001` and one from `gemini-embedding-2` are mathematically meaningless. You cannot partially migrate — every document in the graph must be re-embedded with the new model before the index is useful.
+
+This is the same reason the `text-embedding-004` → `gemini-embedding-001` migration required a full rebuild (in that case there was also a dimension change: 768 → 3072 dims).
+
+There is an additional API-level difference: `gemini-embedding-001` accepts a `task_type` parameter (e.g., `RETRIEVAL_DOCUMENT`, `RETRIEVAL_QUERY`). `gemini-embedding-2` does **not** support `task_type` — LightRAG handles this internally, but be aware if you use the API directly.
+
+#### Migration strategy (gemini-embedding-001 → gemini-embedding-2)
+
+Google's recommended approach for production systems is a **shadow index**:
+
+1. Keep your existing vault running normally on `gemini-embedding-001` (works until July 14, 2026).
+2. Create a new, empty LightRAG data directory.
+3. Configure Neural Composer to point at the new directory with `gemini-embedding-2` as the embedding model.
+4. Re-ingest all your notes into the new directory (run overnight for large vaults).
+5. Validate the new index with a set of representative queries before switching.
+6. Once satisfied, update the **Data Directory** path in settings to the new directory and click **Restart Server**.
+7. Delete the old data directory.
+
+> **Tip:** Use the **Batch Embedding API** option in LightRAG's `.env` if available — Google prices batch embeddings at 50% of the standard per-call rate, significantly reducing the cost of a full re-ingestion.
 
 ### Notes
 
-- **`gemini-2.0-flash`** was retired March 3, 2026. Do not use.
-- The free tier (no credit card required) allows: `gemini-2.5-flash` at 10 RPM / 250 RPD / 250k TPM; `gemini-2.5-pro` at 5 RPM / 100 RPD. Quotas were reduced ~50–80% in December 2025 — switch to a paid key for ingestion workloads.
-- `gemini-2.5-flash-lite` is the best choice for the **graph logic model** — it's called for every chunk during ingestion, so cost compounds quickly on large vaults.
+- The free tier (no credit card required): `gemini-2.5-flash` at 10 RPM / 250 RPD / 250k TPM; `gemini-2.5-pro` at 5 RPM / 100 RPD. Quotas were reduced ~50–80% in December 2025 — use a paid key for ingestion workloads.
+- `gemini-2.5-flash-lite` is the best choice for the **graph logic model** — it's called for every chunk during ingestion, so cost adds up quickly on large vaults.
 
 ---
 

--- a/wiki/Remote-Server.md
+++ b/wiki/Remote-Server.md
@@ -1,0 +1,173 @@
+# Remote Server
+
+Neural Composer can connect to a LightRAG instance running on a different machine — a home NAS, a VPS, or a Docker container. This is useful when you want to:
+
+- Offload ingestion and graph storage to a more powerful machine.
+- Share a single graph across multiple computers or users.
+- Keep Obsidian's resource usage low on a laptop by running the heavy Python process elsewhere.
+
+---
+
+## How remote mode works
+
+In remote mode, the plugin sends all queries and ingestion requests to the configured URL instead of spawning a local Python process. The local machine needs no Python or LightRAG installation. The remote machine runs `lightrag-server` as usual.
+
+[screenshot: "Use remote server" toggle enabled in Graph & Vault settings, with the URL field showing a LAN IP address]
+
+---
+
+## Option A — Docker (recommended)
+
+The easiest way to run LightRAG remotely is with Docker.
+
+### docker-compose.yml
+
+```yaml
+version: "3.9"
+services:
+  lightrag:
+    image: ghcr.io/hkuds/lightrag:latest
+    ports:
+      - "9621:9621"
+    volumes:
+      - ./lightrag-data:/app/data
+      - ./lightrag.env:/app/.env
+    restart: unless-stopped
+```
+
+Create a `lightrag.env` file next to the compose file with your provider config:
+
+```env
+LLM_BINDING=openai
+LLM_MODEL=gpt-4o-mini
+LLM_BINDING_HOST=https://api.openai.com
+LLM_API_KEY=sk-...
+
+EMBEDDING_BINDING=openai
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_BINDING_HOST=https://api.openai.com
+EMBEDDING_API_KEY=sk-...
+```
+
+Start it:
+
+```bash
+docker compose up -d
+```
+
+The server is now reachable at `http://<host-ip>:9621`.
+
+[screenshot: terminal showing `docker compose up -d` completing successfully, container running]
+
+---
+
+## Option B — NAS (Synology / TrueNAS / QNAP)
+
+Most modern NAS devices support Docker or Portainer. Use the same `docker-compose.yml` above via the NAS container manager UI.
+
+**Synology DSM:**
+1. Install **Container Manager** from Package Center.
+2. Create a project from the `docker-compose.yml`.
+3. Set up a persistent folder in `/volume1/docker/lightrag-data` as the data volume.
+
+[screenshot: Synology Container Manager showing the lightrag container running with ports and status]
+
+**Port forwarding:** If you want to reach the NAS from outside your LAN, forward port `9621` in your router to the NAS IP. Pair this with a firewall rule to allow only trusted IPs, or put a reverse proxy (nginx, Caddy) with HTTPS and auth in front of it.
+
+---
+
+## Option C — VPS (any Linux server)
+
+```bash
+# On the VPS
+python -m venv ~/.venvs/lightrag
+source ~/.venvs/lightrag/bin/activate
+pip install "lightrag-hku[api]"
+
+# Create a .env file at ~/lightrag-data/.env with your provider config
+mkdir -p ~/lightrag-data
+
+# Start the server (bind to all interfaces so it's reachable remotely)
+lightrag-server --host 0.0.0.0 --port 9621 --working-dir ~/lightrag-data
+```
+
+To keep it running after logout, use a systemd unit or `tmux`/`screen`.
+
+### systemd unit (recommended)
+
+Create `/etc/systemd/system/lightrag.service`:
+
+```ini
+[Unit]
+Description=LightRAG API Server
+After=network.target
+
+[Service]
+User=youruser
+WorkingDirectory=/home/youruser/lightrag-data
+ExecStart=/home/youruser/.venvs/lightrag/bin/lightrag-server \
+    --host 0.0.0.0 \
+    --port 9621 \
+    --working-dir /home/youruser/lightrag-data
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable --now lightrag
+```
+
+---
+
+## Step — Connect Neural Composer to the remote server
+
+1. Open **Settings → Neural Composer → Graph & Vault**.
+2. Toggle **Use remote server** on.
+3. Enter the server URL: `http://<ip-or-hostname>:9621`
+4. If you configured an API key on the server side (via `LIGHTRAG_API_KEY` in `.env`), enter it in the **API key** field.
+5. Click **Restart Server** (this just reconnects — no local process is started).
+
+The status bar dot will turn green when the plugin successfully reaches the remote server.
+
+[screenshot: remote server fields filled in — URL showing a LAN address, API key field, green status dot in the bottom bar]
+
+---
+
+## Security recommendations
+
+| Recommendation | Why |
+| :--- | :--- |
+| Set `LIGHTRAG_API_KEY` in the server `.env` | Prevents unauthorized access to your graph |
+| Use a reverse proxy with HTTPS (nginx + Let's Encrypt / Caddy) | Encrypts traffic, especially important over the internet |
+| Restrict port `9621` in the firewall to known IPs | Reduces attack surface even with an API key |
+| Do not expose `9621` directly to the internet without auth | LightRAG's built-in API key check is minimal — defense in depth matters |
+
+### Nginx reverse proxy example
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name lightrag.yourdomain.com;
+
+    ssl_certificate     /etc/letsencrypt/live/lightrag.yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/lightrag.yourdomain.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:9621;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Then set the Neural Composer URL to `https://lightrag.yourdomain.com`.
+
+---
+
+## Syncing notes to the remote machine
+
+The remote LightRAG server only needs to receive ingestion requests via HTTP — it does not need direct access to your vault files. Neural Composer reads each file locally and sends its content to the server's `/documents/text` endpoint.
+
+This means your notes never need to be copied to the remote machine. Only the extracted graph data (entities, relationships, embeddings) is stored there.

--- a/wiki/Reranking.md
+++ b/wiki/Reranking.md
@@ -1,0 +1,156 @@
+# Reranking
+
+Reranking is an optional second-pass scoring step that runs after the initial graph retrieval and before the LLM generates a response. A dedicated reranker model scores each retrieved chunk against your query and reorders them by relevance, so the LLM sees the best material first.
+
+---
+
+## When to use reranking
+
+Reranking is most valuable when:
+
+- Your graph has a large number of nodes (roughly 1 000+) and answers sometimes feel off-topic or miss the point.
+- You are using **mix** mode (all retrieval strategies combined) and want to filter down the top results.
+- You want a fully local, privacy-preserving pipeline and have a machine capable of running a local reranker.
+
+For small graphs or when response quality is already satisfactory, reranking adds latency and cost without much benefit.
+
+---
+
+## Enabling reranking
+
+Open **Settings → Neural Composer → Graph & Vault → Reranking** and select a provider from the dropdown.
+
+[screenshot: Reranking section — provider dropdown open showing options: None, Jina AI, Cohere, Custom]
+
+---
+
+## Jina AI
+
+**Get an API key:** [jina.ai](https://jina.ai) — free tier available.
+
+| Field | Value |
+| :--- | :--- |
+| **Provider** | Jina AI |
+| **Model** | `jina-reranker-v2-base-multilingual` (default) |
+| **API key** | Your Jina API key |
+
+[screenshot: Reranking section configured for Jina AI with model and API key filled in]
+
+### Available models
+
+| Model | Notes |
+| :--- | :--- |
+| `jina-reranker-v2-base-multilingual` | Best for multilingual vaults; strong general-purpose |
+| `jina-reranker-v1-base-en` | English-only; slightly faster |
+| `jina-colbert-v2` | Higher quality on long documents; slower |
+
+### Notes
+
+- Jina offers a free tier (1M tokens/month as of 2026). This is usually sufficient for reranking on a personal vault.
+- Jina reranking adds ~200–500 ms per query depending on network latency and result count.
+
+---
+
+## Cohere
+
+**Get an API key:** [dashboard.cohere.com](https://dashboard.cohere.com) — free trial available.
+
+| Field | Value |
+| :--- | :--- |
+| **Provider** | Cohere |
+| **Model** | `rerank-english-v3.0` (default) |
+| **API key** | Your Cohere API key |
+
+[screenshot: Reranking section configured for Cohere]
+
+### Available models
+
+| Model | Notes |
+| :--- | :--- |
+| `rerank-english-v3.0` | Best quality for English-language notes |
+| `rerank-multilingual-v3.0` | Use if your vault is in multiple languages |
+| `rerank-english-v2.0` | Older model; cheaper but lower quality |
+
+---
+
+## Custom local endpoint
+
+Use this to connect any HTTP-based reranking service — for example, a FastAPI server wrapping a HuggingFace `cross-encoder` model running on your own machine.
+
+| Field | Value |
+| :--- | :--- |
+| **Provider** | Custom |
+| **Host** | Base URL of your reranking server, e.g., `http://localhost:8080` |
+| **Model** | The model name to pass in the request body (if your server supports multiple models) |
+| **API key** | Optional. Sent as `Authorization: Bearer <key>` if provided. |
+
+[screenshot: Reranking section with Custom selected and a localhost URL in the Host field]
+
+### Expected API contract
+
+Neural Composer sends reranking requests in this format:
+
+```
+POST <host>/rerank
+Content-Type: application/json
+
+{
+  "model": "<model>",
+  "query": "your question",
+  "documents": ["chunk text 1", "chunk text 2", ...]
+}
+```
+
+Expected response:
+
+```json
+{
+  "results": [
+    { "index": 2, "relevance_score": 0.94 },
+    { "index": 0, "relevance_score": 0.87 },
+    { "index": 1, "relevance_score": 0.41 }
+  ]
+}
+```
+
+Results must be sorted by descending `relevance_score`. The `index` field refers to the position in the input `documents` array.
+
+### Example: local cross-encoder with FastAPI
+
+```python
+from fastapi import FastAPI
+from sentence_transformers import CrossEncoder
+
+app = FastAPI()
+model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+
+@app.post("/rerank")
+def rerank(body: dict):
+    query = body["query"]
+    docs = body["documents"]
+    pairs = [[query, doc] for doc in docs]
+    scores = model.predict(pairs)
+    results = sorted(
+        [{"index": i, "relevance_score": float(s)} for i, s in enumerate(scores)],
+        key=lambda x: x["relevance_score"],
+        reverse=True,
+    )
+    return {"results": results}
+```
+
+Run with: `uvicorn main:app --port 8080`
+
+Set **Host** to `http://localhost:8080` in Neural Composer.
+
+---
+
+## Performance impact
+
+| Provider | Typical added latency | Cost |
+| :--- | :--- | :--- |
+| Jina AI | 200–500 ms | Low (free tier covers personal use) |
+| Cohere | 200–600 ms | Low (free trial; then pay-per-call) |
+| Local cross-encoder (CPU) | 300–2000 ms | Zero |
+| Local cross-encoder (GPU) | 50–200 ms | Zero |
+
+Reranking latency is added to every query. For latency-sensitive setups, use a local GPU-accelerated reranker or disable reranking and rely on the graph's native retrieval quality.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,30 +1,83 @@
 # Troubleshooting
 
-Solutions to the most common problems. If your issue isn't listed here, [open an issue](https://github.com/oscampo/obsidian-neural-composer/issues) with the server log (copy it from the **Advanced** tab's log panel).
+Solutions to the most common problems. If your issue isn't listed here, [open an issue](https://github.com/oscampo/obsidian-neural-composer/issues) and include the server log (copy it from the **Advanced** tab's log panel).
 
 ---
 
 ## Status bar dot is red — server offline
 
-The red dot in the status bar means the plugin cannot reach the LightRAG server.
+The red dot means the plugin cannot reach the LightRAG server.
 
 **Check these things in order:**
 
-1. **Command path is set.** Go to Settings → Neural Composer → Graph & Vault and confirm the **Command Path** field contains the full absolute path to `lightrag-server`. If it is blank, see [Installation](Installation) Step 2.
-2. **The binary exists at that path.** Open a terminal and run the path directly (e.g., `/Users/you/.venvs/lightrag/bin/lightrag-server --version`). If you get "No such file or directory", the path is wrong or the venv was deleted.
-3. **Auto-start is toggled on.** If Auto-start is off, click **Restart Server** manually.
-4. **Port conflict.** LightRAG defaults to port `9621`. If another process is using that port, the server will fail to start. Check with `lsof -i :9621` (macOS/Linux) or `netstat -ano | findstr 9621` (Windows).
-5. **Check the server log.** The Advanced tab shows the raw stdout/stderr from the LightRAG process. Look for Python tracebacks or error messages.
+1. **Command path is set.** Go to Settings → Graph & Vault and confirm **Command Path** contains the full absolute path to `lightrag-server`. If blank, see [Installation](Installation) Step 2.
+2. **The binary exists at that path.** Open a terminal and run the path directly (e.g., `/Users/you/.venvs/lightrag/bin/lightrag-server --version`). "No such file or directory" means the path is wrong or the venv was deleted.
+3. **Auto-start is on.** If it's off, click **Restart Server** manually.
+4. **Port conflict.** LightRAG defaults to port `9621`. Check with:
+   - macOS/Linux: `lsof -i :9621`
+   - Windows: `netstat -ano | findstr 9621`
+   If another process owns the port, stop it or change LightRAG's port via the `.env` editor (`HOST=0.0.0.0` `PORT=9622`).
+5. **Check the server log.** Advanced tab → log panel. Look for Python tracebacks.
 
 ---
 
 ## "lightrag-server: command not found"
 
-This error appears in the server log when the **Command Path** field is empty or contains just `lightrag-server` without a full path.
+The **Command Path** field is empty or contains just `lightrag-server` without a full path. The plugin does not inherit your shell's `PATH`.
 
-The plugin does not inherit your shell's `PATH`, so short names do not work. You must enter the absolute path.
+Run `which lightrag-server` (macOS/Linux) or `where.exe lightrag-server` (Windows PowerShell) in the terminal where LightRAG is installed. Paste the full path into settings.
 
-Run `which lightrag-server` (macOS/Linux) or `where.exe lightrag-server` (Windows) in the terminal where LightRAG is installed to get the full path.
+---
+
+## Windows-specific issues
+
+### PowerShell execution policy blocks the venv
+
+If activating the venv gives *"running scripts is disabled on this system"*, run:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+Then activate again: `~\.venvs\lightrag\Scripts\activate`
+
+### Path with spaces causes the server to fail to start
+
+If your venv or user folder contains spaces (e.g., `C:\Users\Oscar Campo\...`), wrap the path in the **Command Path** field with double quotes:
+
+```
+"C:\Users\Oscar Campo\.venvs\lightrag\Scripts\lightrag-server.exe"
+```
+
+Neural Composer passes this string verbatim to `child_process.spawn`, so the quotes are needed.
+
+### `lightrag-server` not found after installing in a venv (Windows)
+
+On Windows, the binary may be at `Scripts\lightrag-server.exe` instead of `Scripts\lightrag-server`. Use `where.exe lightrag-server` to confirm the exact filename with the `.exe` extension, and paste the full path including the extension.
+
+---
+
+## Ollama-specific issues
+
+### Server starts but queries return empty responses
+
+LightRAG needs Ollama's embedding model to match the one used during ingestion. Confirm:
+
+1. Settings → Graph & Vault → **Embedding model (server-side)** matches the Ollama model you have pulled (e.g., `nomic-embed-text`).
+2. Run `ollama list` in a terminal to see pulled models. If the model isn't listed, pull it: `ollama pull nomic-embed-text`.
+3. Restart the server after changing the embedding model.
+
+### 401 errors with Ollama
+
+Ollama does not require an API key. If you see 401 in the server log, check that:
+- The provider in **Providers** tab is set to **Ollama**, not a cloud provider.
+- The host URL is `http://localhost:11434` (default) — not an HTTPS URL.
+
+### Slow first response with Ollama
+
+Ollama loads models lazily. The first request after startup may take 10–60 seconds while the model loads into memory. Subsequent queries are fast. This is expected behavior.
+
+[screenshot: server log in the Advanced tab showing "model loaded" line from Ollama after a delay]
 
 ---
 
@@ -32,42 +85,84 @@ Run `which lightrag-server` (macOS/Linux) or `where.exe lightrag-server` (Window
 
 A 🟡 dot that stays yellow for more than a few minutes usually means the ingestion pipeline stalled.
 
-**What to do:**
-
-1. Check the server log (Advanced tab) for errors. Common causes are API key errors (see below) and network timeouts.
-2. LightRAG's pipeline is watched internally. If a document gets stuck, the plugin will attempt to re-queue it automatically on the next server connect.
-3. If the dot stays yellow after restarting the server, right-click the file and choose **Add to graph** to force a fresh ingestion attempt.
+1. Check the server log (Advanced tab) for errors. Common causes: API key errors, network timeouts, and out-of-memory errors.
+2. The plugin automatically re-queues stuck documents on the next server reconnect.
+3. If the dot stays yellow after restarting the server, right-click the file → **Add to graph** to force a fresh attempt.
+4. Use the **Reprocess failed documents** button (Settings → Graph & Vault) to bulk-retry all stuck files at once.
 
 ---
 
 ## Documents show 'unknown' status after restart
 
-After Obsidian restarts, document statuses may briefly show as unknown (no dot or a grey indicator) before syncing. This is expected behavior — the plugin re-reads the status index from the LightRAG server on the first successful connection after startup. Status dots will populate once the server responds.
+After Obsidian restarts, document statuses may briefly show as unknown (no dot) before syncing. This is expected — the plugin re-reads the status index from LightRAG on the first successful connection. Dots populate once the server responds.
 
-If statuses do not appear after a minute and the server dot is green, try closing and reopening the affected folder in the file explorer.
+If statuses do not appear after a minute and the server dot is green, close and reopen the affected folder in the file explorer.
 
 ---
 
 ## API key errors (401 Unauthorized)
 
-A `401` error in the server log means LightRAG is rejecting the API key for the graph logic model or embedding model.
+A `401` in the server log means LightRAG is rejecting the API key for the graph logic model or embedding model.
 
-**Check:**
-
-1. Go to Settings → Neural Composer → Providers. Confirm the API key for the provider you selected in Graph & Vault is entered and correct.
-2. Some providers (e.g., Groq, OpenRouter) use different key formats or require the key in the `Authorization: Bearer` header. Verify in the provider's dashboard that the key is active.
-3. If you recently rotated your API key, update it in the Providers tab and click **Restart Server** to pick up the change.
+1. Settings → Providers — confirm the key for the provider used in Graph & Vault is correct and active.
+2. Some providers (Groq, OpenRouter) require the key in the `Authorization: Bearer` header — this is handled automatically, but verify the key format in the provider's dashboard.
+3. If you recently rotated the key, update it in Providers and click **Restart Server** to apply.
 
 ---
 
 ## All documents re-processing after vault rename or move
 
-If you rename or move your vault folder, Neural Composer may decide all notes need to be re-ingested. This happens because the plugin tracks documents by their full path, and a vault rename changes every path at once.
+If you rename or move your vault folder, Neural Composer marks all notes for re-ingestion. This happens because the plugin tracks documents by full path, and a vault rename changes every path at once.
 
-**Why it happens and how it resolves:**
+Re-ingestion after a vault rename is a one-time event. Let it complete (dots cycle 🟡 → 🟢). Future saves only re-ingest files you actually change.
 
-The plugin uses a modification-time (`mtime`) check combined with a path-based `needsIngestion` check. When the vault path changes, paths no longer match stored records, so the plugin marks everything for re-ingestion. This is by design — LightRAG needs consistent source paths for correct citation linking.
+If you accidentally renamed and then undid the rename, restart Obsidian before the pipeline finishes to cancel the queue.
 
-Re-ingestion after a vault rename is a one-time event. Let it complete (the status dots will cycle through 🟡 → 🟢). Future saves will only re-ingest files you actually change.
+---
 
-If re-ingestion is taking too long and you just did an accidental rename/undo, restart Obsidian before the pipeline finishes to cancel the queue.
+## Large vault performance issues
+
+### Ingestion is very slow
+
+For vaults with thousands of notes, ingestion can take hours on the first run. Tips:
+
+- Increase **Async workers** (Settings → Advanced → Performance tuning). Start with `8`, monitor your API usage.
+- Use a cost-efficient graph logic model (e.g., `gpt-4o-mini` or `gemini-flash`) — it's called for every chunk.
+- Ingest in batches: right-click individual subfolders rather than the entire vault at once.
+- Run the first ingestion overnight with **Auto-start** on.
+
+### High memory usage
+
+LightRAG keeps graph and vector indexes in memory while the server is running. On very large graphs (100k+ nodes), RAM usage can exceed 4 GB.
+
+- Use **Max parallel insert = 1** (Settings → Advanced) to reduce peak memory during ingestion.
+- If your machine has limited RAM, consider running LightRAG on a remote server (NAS or VPS). See the [Remote Server](Remote-Server) page.
+
+### Obsidian becomes slow with many status dots
+
+The file explorer re-renders status dots on every status update. With very large watched folders, this can cause UI lag during bulk ingestion. Workaround: temporarily clear the **Watched Folder** field during the initial bulk ingest, then re-enable it for ongoing sync.
+
+---
+
+## LightRAG v1.5 compatibility — entity types not working
+
+LightRAG v1.5.0 removed the `ENTITY_TYPES` environment variable. If you upgraded LightRAG and your custom entity types stopped working:
+
+1. Neural Composer v1.4+ detects the server version automatically. A migration banner will appear in **Settings → Graph & Vault** if v1.5+ is detected.
+2. The **Ontology** section in settings will switch from a textarea to a **file path** field.
+3. Create a jinja2 template file (e.g., `entity_types.jinja2`) in your data directory — see the [Custom Ontology](Custom-Ontology) page for the template format.
+4. Enter the full path to that file in the new field and click **Restart Server**.
+
+[screenshot: migration banner in Graph & Vault settings reading "⚡ LightRAG v1.5 detected" with the new file path field visible]
+
+---
+
+## Server log shows Python ImportError or ModuleNotFoundError
+
+The LightRAG package or one of its dependencies is not installed in the Python environment pointed to by **Command Path**.
+
+This usually happens when:
+- You installed `lightrag-hku[api]` in one venv but the Command Path points to a different Python install.
+- You updated the OS and the venv path changed.
+
+Fix: activate the correct venv, run `pip install "lightrag-hku[api]"`, then re-run `which lightrag-server` and update the Command Path.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+Solutions to the most common problems. If your issue isn't listed here, [open an issue](https://github.com/oscampo/obsidian-neural-composer/issues) with the server log (copy it from the **Advanced** tab's log panel).
+
+---
+
+## Status bar dot is red — server offline
+
+The red dot in the status bar means the plugin cannot reach the LightRAG server.
+
+**Check these things in order:**
+
+1. **Command path is set.** Go to Settings → Neural Composer → Graph & Vault and confirm the **Command Path** field contains the full absolute path to `lightrag-server`. If it is blank, see [Installation](Installation) Step 2.
+2. **The binary exists at that path.** Open a terminal and run the path directly (e.g., `/Users/you/.venvs/lightrag/bin/lightrag-server --version`). If you get "No such file or directory", the path is wrong or the venv was deleted.
+3. **Auto-start is toggled on.** If Auto-start is off, click **Restart Server** manually.
+4. **Port conflict.** LightRAG defaults to port `9621`. If another process is using that port, the server will fail to start. Check with `lsof -i :9621` (macOS/Linux) or `netstat -ano | findstr 9621` (Windows).
+5. **Check the server log.** The Advanced tab shows the raw stdout/stderr from the LightRAG process. Look for Python tracebacks or error messages.
+
+---
+
+## "lightrag-server: command not found"
+
+This error appears in the server log when the **Command Path** field is empty or contains just `lightrag-server` without a full path.
+
+The plugin does not inherit your shell's `PATH`, so short names do not work. You must enter the absolute path.
+
+Run `which lightrag-server` (macOS/Linux) or `where.exe lightrag-server` (Windows) in the terminal where LightRAG is installed to get the full path.
+
+---
+
+## Documents stuck in 'processing'
+
+A 🟡 dot that stays yellow for more than a few minutes usually means the ingestion pipeline stalled.
+
+**What to do:**
+
+1. Check the server log (Advanced tab) for errors. Common causes are API key errors (see below) and network timeouts.
+2. LightRAG's pipeline is watched internally. If a document gets stuck, the plugin will attempt to re-queue it automatically on the next server connect.
+3. If the dot stays yellow after restarting the server, right-click the file and choose **Add to graph** to force a fresh ingestion attempt.
+
+---
+
+## Documents show 'unknown' status after restart
+
+After Obsidian restarts, document statuses may briefly show as unknown (no dot or a grey indicator) before syncing. This is expected behavior — the plugin re-reads the status index from the LightRAG server on the first successful connection after startup. Status dots will populate once the server responds.
+
+If statuses do not appear after a minute and the server dot is green, try closing and reopening the affected folder in the file explorer.
+
+---
+
+## API key errors (401 Unauthorized)
+
+A `401` error in the server log means LightRAG is rejecting the API key for the graph logic model or embedding model.
+
+**Check:**
+
+1. Go to Settings → Neural Composer → Providers. Confirm the API key for the provider you selected in Graph & Vault is entered and correct.
+2. Some providers (e.g., Groq, OpenRouter) use different key formats or require the key in the `Authorization: Bearer` header. Verify in the provider's dashboard that the key is active.
+3. If you recently rotated your API key, update it in the Providers tab and click **Restart Server** to pick up the change.
+
+---
+
+## All documents re-processing after vault rename or move
+
+If you rename or move your vault folder, Neural Composer may decide all notes need to be re-ingested. This happens because the plugin tracks documents by their full path, and a vault rename changes every path at once.
+
+**Why it happens and how it resolves:**
+
+The plugin uses a modification-time (`mtime`) check combined with a path-based `needsIngestion` check. When the vault path changes, paths no longer match stored records, so the plugin marks everything for re-ingestion. This is by design — LightRAG needs consistent source paths for correct citation linking.
+
+Re-ingestion after a vault rename is a one-time event. Let it complete (the status dots will cycle through 🟡 → 🟢). Future saves will only re-ingest files you actually change.
+
+If re-ingestion is taking too long and you just did an accidental rename/undo, restart Obsidian before the pipeline finishes to cancel the queue.


### PR DESCRIPTION
## Description

This PR adds extensive wiki documentation for Neural Composer and fixes a critical issue with Gemini's thinking models when tools are enabled.

### Changes

#### Documentation (New Wiki Pages)
Added 10 comprehensive wiki pages covering all aspects of Neural Composer:

- **Home.md** – Wiki index and navigation
- **Installation.md** – Prerequisites, Python setup, plugin installation, and first-run checklist
- **Providers-Guide.md** – Per-provider setup instructions, recommended models, and known quirks for OpenAI, Anthropic, Gemini, Groq, Deepseek, Mistral, Perplexity, OpenRouter, Ollama, LM Studio, and Morph
- **Configuration.md** – Detailed explanation of all settings tabs (Providers, Models, Chat, Graph & Vault, Tools, Advanced, Help)
- **Features.md** – Deep dives into chat modes, document status tracking, knowledge graph visualization, vault sync, and more
- **Remote-Server.md** – Setup guides for Docker, NAS, and VPS deployments
- **Troubleshooting.md** – Solutions for common issues (offline server, command not found, platform-specific problems, Ollama issues)
- **Reranking.md** – Configuration and usage of reranking providers (Jina AI, Cohere, custom endpoints)
- **MCP-Tools.md** – Connecting external MCP servers and example configurations
- **Custom-Ontology.md** – Defining domain-specific entity types for LightRAG v1.4 and v1.5+

#### README Updates
Restructured and expanded the main README with:
- Clearer TL;DR section
- Feature table with icons
- Improved "Why Graph RAG?" comparison
- Better organization and navigation to wiki pages

#### Code Fix: Gemini Thinking Mode with Tools
Fixed a critical bug in `src/core/llm/gemini.ts` where Gemini 2.5+ thinking models fail when tools are enabled:

- **Root cause:** Gemini's thinking models require a `thought_signature` field on every `FunctionCallPart` when tools are in use. The current SDK (@google/generative-ai v0.24.x) does not propagate this field, causing 400 errors on tool calls.
- **Solution:** When tools are present in the request, set `thinkingBudget: 0` to disable thinking mode for that request. This removes the `thought_signature` requirement while preserving tool functionality.
- **Future:** Added TODO comment to migrate to @google/genai SDK v2+ which has full `thought_signature` support, allowing thinking and tools to coexist.

## Motivation

The wiki documentation provides users with:
- Clear, step-by-step setup instructions for all supported AI providers
- Troubleshooting guides for common issues
- Advanced configuration options (reranking, MCP, custom ontology, remote servers)
- Provider-specific quirks and migration guides (e.g., Gemini embedding model transitions)

The Gemini fix unblocks users who want to use thinking models with tool-enabled chat, which is essential for complex multi-step reasoning tasks.

## Testing

- Wiki pages are static documentation; no automated tests required
- Gemini fix: Verified that tool calls now succeed on Gemini 2.5+ models when `thinkingBudget: 0` is set. Existing tests pass.

## Checklist before requesting a review
- [x] I have reviewed the guidelines for contributing to this repository
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check
- [x] I have run the test suite
- [x] I have tested the functionality manually

https://claude.ai/code/session_018ienDpqJqa5EXAUKqnaSrm