### PR TITLE
fix(gemini): propagate thought_signature through tool call pipeline

### DIFF
--- a/src/core/llm/gemini.ts
+++ b/src/core/llm/gemini.ts
@@ -277,7 +277,9 @@ export class GeminiProvider extends BaseLLMProvider<
             } catch {
               // If the arguments are not valid JSON, return an empty object
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const part: any = { functionCall: { name: toolCall.name, args: {} } }
+              const part: any = {
+                functionCall: { name: toolCall.name, args: {} },
+              }
               if (toolCall.thought_signature) {
                 part.thoughtSignature = toolCall.thought_signature
               }
@@ -329,7 +331,8 @@ export class GeminiProvider extends BaseLLMProvider<
               // Use raw candidates parts so we can capture thoughtSignature.
               // response.response.functionCalls() discards that field.
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const parts = (response.response.candidates?.[0]?.content?.parts ?? []) as any[]
+              const parts = (response.response.candidates?.[0]?.content
+                ?.parts ?? []) as any[]
               const fnParts = parts.filter((p) => p.functionCall)
               if (fnParts.length === 0) return undefined
               return fnParts.map((part) => ({
@@ -375,7 +378,8 @@ export class GeminiProvider extends BaseLLMProvider<
               // Use raw candidates parts so we can capture thoughtSignature.
               // chunk.functionCalls() discards that field.
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const parts = (chunk.candidates?.[0]?.content?.parts ?? []) as any[]
+              const parts = (chunk.candidates?.[0]?.content?.parts ??
+                []) as any[]
               const fnParts = parts.filter((p) => p.functionCall)
               if (fnParts.length === 0) return undefined
               return fnParts.map((part, index) => ({

--- a/src/core/llm/gemini.ts
+++ b/src/core/llm/gemini.ts
@@ -268,20 +268,20 @@ export class GeminiProvider extends BaseLLMProvider<
           ...(message.tool_calls?.map((toolCall): FunctionCallPart => {
             try {
               const args = JSON.parse(toolCall.arguments ?? '{}')
-              return {
-                functionCall: {
-                  name: toolCall.name,
-                  args,
-                },
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const part: any = { functionCall: { name: toolCall.name, args } }
+              if (toolCall.thought_signature) {
+                part.thoughtSignature = toolCall.thought_signature
               }
+              return part as FunctionCallPart
             } catch {
               // If the arguments are not valid JSON, return an empty object
-              return {
-                functionCall: {
-                  name: toolCall.name,
-                  args: {},
-                },
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const part: any = { functionCall: { name: toolCall.name, args: {} } }
+              if (toolCall.thought_signature) {
+                part.thoughtSignature = toolCall.thought_signature
               }
+              return part as FunctionCallPart
             }
           }) ?? []),
         ]
@@ -325,14 +325,23 @@ export class GeminiProvider extends BaseLLMProvider<
           message: {
             content: response.response.text(),
             role: 'assistant',
-            tool_calls: response.response.functionCalls()?.map((f) => ({
-              id: uuidv4(),
-              type: 'function',
-              function: {
-                name: f.name,
-                arguments: JSON.stringify(f.args),
-              },
-            })),
+            tool_calls: (() => {
+              // Use raw candidates parts so we can capture thoughtSignature.
+              // response.response.functionCalls() discards that field.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const parts = (response.response.candidates?.[0]?.content?.parts ?? []) as any[]
+              const fnParts = parts.filter((p) => p.functionCall)
+              if (fnParts.length === 0) return undefined
+              return fnParts.map((part) => ({
+                id: uuidv4(),
+                type: 'function' as const,
+                function: {
+                  name: part.functionCall.name,
+                  arguments: JSON.stringify(part.functionCall.args),
+                },
+                thought_signature: part.thoughtSignature ?? undefined,
+              }))
+            })(),
           },
         },
       ],
@@ -362,15 +371,24 @@ export class GeminiProvider extends BaseLLMProvider<
           finish_reason: chunk.candidates?.[0]?.finishReason ?? null,
           delta: {
             content: chunk.text(),
-            tool_calls: chunk.functionCalls()?.map((f, index) => ({
-              index,
-              id: uuidv4(),
-              type: 'function',
-              function: {
-                name: f.name,
-                arguments: JSON.stringify(f.args),
-              },
-            })),
+            tool_calls: (() => {
+              // Use raw candidates parts so we can capture thoughtSignature.
+              // chunk.functionCalls() discards that field.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const parts = (chunk.candidates?.[0]?.content?.parts ?? []) as any[]
+              const fnParts = parts.filter((p) => p.functionCall)
+              if (fnParts.length === 0) return undefined
+              return fnParts.map((part, index) => ({
+                index,
+                id: uuidv4(),
+                type: 'function' as const,
+                function: {
+                  name: part.functionCall.name,
+                  arguments: JSON.stringify(part.functionCall.args),
+                },
+                thought_signature: part.thoughtSignature ?? undefined,
+              }))
+            })(),
           },
         },
       ],

--- a/src/types/llm/response.ts
+++ b/src/types/llm/response.ts
@@ -74,6 +74,7 @@ export type ToolCall = {
     arguments?: string
     name: string
   }
+  thought_signature?: string // Gemini thinking models (2.5+)
 }
 
 export type ToolCallDelta = {
@@ -84,4 +85,5 @@ export type ToolCallDelta = {
     arguments?: string
     name?: string
   }
+  thought_signature?: string // Gemini thinking models (2.5+)
 }

--- a/src/types/tool-call.types.ts
+++ b/src/types/tool-call.types.ts
@@ -2,6 +2,7 @@ export type ToolCallRequest = {
   id: string
   name: string
   arguments?: string
+  thought_signature?: string // Gemini thinking models (2.5+) require this on multi-turn tool calls
 }
 
 export type ToolCallResponse =

--- a/src/utils/chat/responseGenerator.ts
+++ b/src/utils/chat/responseGenerator.ts
@@ -336,7 +336,8 @@ export class ResponseGenerator {
         index,
         id: merged[index].id ?? toolCall.id,
         type: merged[index].type ?? toolCall.type,
-        thought_signature: merged[index].thought_signature ?? toolCall.thought_signature,
+        thought_signature:
+          merged[index].thought_signature ?? toolCall.thought_signature,
       }
 
       if (merged[index].function || toolCall.function) {

--- a/src/utils/chat/responseGenerator.ts
+++ b/src/utils/chat/responseGenerator.ts
@@ -217,6 +217,7 @@ export class ResponseGenerator {
           id: toolCall.id ?? uuidv4(),
           name: toolCall.function.name,
           arguments: toolCall.function.arguments,
+          thought_signature: toolCall.thought_signature,
         }
       })
       .filter((toolCall) => toolCall !== null)
@@ -335,6 +336,7 @@ export class ResponseGenerator {
         index,
         id: merged[index].id ?? toolCall.id,
         type: merged[index].type ?? toolCall.type,
+        thought_signature: merged[index].thought_signature ?? toolCall.thought_signature,
       }
 
       if (merged[index].function || toolCall.function) {


### PR DESCRIPTION
The PR #31 squash merge included the thinkingBudget=0 workaround in gemini.ts but missed the companion type changes and thought_signature propagation logic. This commit adds the complete fix:

- ToolCallRequest: add thought_signature? field
- ToolCall / ToolCallDelta: add thought_signature? field
- gemini.ts parseNonStreamingResponse: use raw candidates parts instead of response.functionCalls() so thoughtSignature is captured
- gemini.ts parseStreamingResponseChunk: same raw-parts approach
- gemini.ts parseRequestMessage: forward thought_signature back to Gemini API on assistant turns (required for multi-turn tool calls with Gemini 2.5+ thinking models when thinkingBudget>0)
- responseGenerator mergeToolCallDeltas: preserve thought_signature when merging streaming deltas
- responseGenerator ToolCallRequest conversion: pass through thought_signature from merged delta to ToolCallRequest

Together with the thinkingBudget=0 guard already in main, this ensures tool calls work reliably with all Gemini 2.5+ configurations.

https://claude.ai/code/session_018ienDpqJqa5EXAUKqnaSrm

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. If it fixes an issue or resolves a feature request, please include the link to the issue or feature request.

Note: If your changes include UI modifications, please include screenshots to help reviewers visualize the changes.

## Checklist before requesting a review
- [ ] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [ ] I have performed a self-review of my code
- [ ] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [ ] I have run the test suite (by running `npm run test`)
- [ ] I have tested the functionality manually
