### PR TITLE
Folder context menu: "Ingest" XOR "Remove from graph"

### DIFF
--- a/src/core/rag/ragEngine.ts
+++ b/src/core/rag/ragEngine.ts
@@ -183,6 +183,55 @@ export class RAGEngine {
 
   // --- 2b. INCREMENTAL SYNC HELPERS ---
 
+  /**
+   * Paginate through `/documents/paginated` and return every `file_path`
+   * currently known to the LightRAG server. Used by the folder context menu
+   * to decide whether to offer "Ingest folder" vs "Remove folder from graph".
+   *
+   * Returns an empty array on transport / auth failure — callers must treat
+   * "I don't know" the same as "no data" and fall back to showing both menu
+   * items.
+   */
+  async listAllDocumentPaths(): Promise<string[]> {
+    const pageSize = 200
+    const paths: string[] = []
+    let page = 1
+    try {
+      // Hard cap to avoid runaway loops if the server reports `has_next: true`
+      // forever for some reason.
+      while (page <= 200) {
+        const response = await requestUrl({
+          url: `${this.settings.lightRagServerUrl}/documents/paginated`,
+          method: 'POST',
+          headers: this.getLightRagHeaders(),
+          body: JSON.stringify({
+            page,
+            page_size: pageSize,
+            sort_field: 'file_path',
+            sort_direction: 'asc',
+          }),
+          throw: false,
+        })
+        if (response.status >= 400) break
+        const data = response.json as {
+          documents?: { id: string; file_path?: string | null }[]
+          pagination?: { has_next?: boolean }
+        }
+        for (const doc of data.documents ?? []) {
+          if (typeof doc.file_path === 'string' && doc.file_path.length > 0) {
+            paths.push(doc.file_path)
+          }
+        }
+        if (!data.pagination?.has_next) break
+        page++
+      }
+    } catch (e) {
+      console.error('listAllDocumentPaths failed:', e)
+      return []
+    }
+    return paths
+  }
+
   // Finds a LightRAG doc_id matching the given file.
   // Tries the full vault-relative path first (v1.2+ ingest), then falls back to
   // bare filename (pre-v1.2 ingest used file.name instead of file.path).

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {
 import { ApplyView } from './ApplyView'
 import { ChatView } from './ChatView'
 import { ChatProps } from './components/chat-view/Chat'
+import { ConfirmModal } from './components/modals/ConfirmModal'
 import { APPLY_VIEW_TYPE, CHAT_VIEW_TYPE } from './constants'
 import { McpManager } from './core/mcp/mcpManager'
 import { RAGEngine } from './core/rag/ragEngine'
@@ -344,6 +345,14 @@ export default class NeuralComposerPlugin extends Plugin {
               .setIcon('layers')
               .onClick(() => {
                 void this.batchIngestFolder(file)
+              })
+          })
+          menu.addItem((item) => {
+            item
+              .setTitle('Remove folder from graph')
+              .setIcon('trash-2')
+              .onClick(() => {
+                void this.batchRemoveFolderFromGraph(file)
               })
           })
         }
@@ -882,6 +891,85 @@ export default class NeuralComposerPlugin extends Plugin {
     } catch (error) {
       console.error('Batch error:', error)
       notice.setMessage('Error starting upload.')
+      setTimeout(() => notice.hide(), 5000)
+    }
+  }
+
+  /**
+   * Delete every ingested document under a folder (and its subfolders) from
+   * the LightRAG graph. Iterates the same supported-extension set as the
+   * ingest counterpart and calls deleteDocumentByFilePath per file — LightRAG
+   * returns success only for docs it actually knew about, so files that were
+   * never ingested are silently skipped.
+   *
+   * Files inside the configured Watched folder also get marked as `removed`
+   * in the local docIndexService so the file-explorer dots flip blue and
+   * the next file-change event doesn't auto-reingest them.
+   */
+  async batchRemoveFolderFromGraph(folder: TFolder) {
+    const files = this.getAllSupportedFiles(folder)
+    if (files.length === 0) {
+      new Notice('Empty folder or no supported files.')
+      return
+    }
+
+    new ConfirmModal(this.app, {
+      title: 'Remove folder from graph',
+      message: `Remove ${files.length} file${
+        files.length === 1 ? '' : 's'
+      } in "${folder.path}" (and its subfolders) from the ${BACKEND_NAME} graph?\n\nThe files themselves stay in the vault.`,
+      ctaText: 'Remove',
+      onConfirm: () => {
+        void this.executeBatchRemoveFolderFromGraph(folder, files)
+      },
+    }).open()
+  }
+
+  private async executeBatchRemoveFolderFromGraph(
+    folder: TFolder,
+    files: TFile[],
+  ) {
+    const notice = new Notice(`Removing ${files.length} files from graph...`, 0)
+    const syncFolder = this.settings.lightRagSyncFolder.trim()
+    const isInWatchedFolder = (path: string) =>
+      !!syncFolder && (path === syncFolder || path.startsWith(syncFolder + '/'))
+
+    try {
+      const ragEngine = await this.getRAGEngine()
+      let removed = 0
+      let missing = 0
+
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i]
+        notice.setMessage(`Removing (${i + 1}/${files.length}):\n${file.name}`)
+        try {
+          const ok = await ragEngine.deleteDocumentByFilePath(
+            file.path,
+            file.name,
+          )
+          if (ok) {
+            removed++
+            if (isInWatchedFolder(file.path)) {
+              this.docIndexService?.setRemoved(file.path)
+            }
+          } else {
+            missing++
+          }
+        } catch (err) {
+          console.error(`Error removing ${file.name}:`, err)
+          missing++
+        }
+      }
+
+      notice.setMessage(
+        `Removed ${removed} from "${folder.path}"` +
+          (missing > 0 ? ` (${missing} not in graph)` : ''),
+      )
+      setTimeout(() => notice.hide(), 4000)
+      this.decorateFileExplorer()
+    } catch (error) {
+      console.error('Batch remove error:', error)
+      notice.setMessage('Error removing files from graph.')
       setTimeout(() => notice.hide(), 5000)
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,6 +152,21 @@ export default class NeuralComposerPlugin extends Plugin {
   /** True once at least one health check has completed (distinguishes "not yet checked" from "offline"). */
   public lightRagServerChecked = false
 
+  /**
+   * Set of vault-relative folder paths that contain at least one document
+   * currently in the LightRAG graph. Populated from /documents/paginated on
+   * plugin load (after the server is reachable) and refreshed after each
+   * batch-ingest / batch-remove. The folder context menu reads this to
+   * decide whether to show "Ingest folder into graph" or "Remove folder
+   * from graph" — never both.
+   *
+   * Empty when the server hasn't been queried yet OR the request failed;
+   * callers must treat "I don't know" the same way and show both menu
+   * items so the user can still act.
+   */
+  private ingestedFolderPaths: Set<string> = new Set()
+  private ingestedFolderPathsLoaded = false
+
   private versionChangeListeners: Set<
     (info: { version: string | null; checked: boolean }) => void
   > = new Set()
@@ -336,25 +351,38 @@ export default class NeuralComposerPlugin extends Plugin {
     })
 
     // --- CONTEXT MENU (FOLDERS) ---
+    // The menu shows exactly one of "Ingest" / "Remove from graph" based on
+    // whether the folder has any descendants currently in the LightRAG
+    // graph. When we haven't loaded the ingested-folders cache yet (e.g.
+    // server unreachable on startup), fall back to showing both so the user
+    // can still take action.
     this.registerEvent(
       this.app.workspace.on('file-menu', (menu, file) => {
         if (file instanceof TFolder) {
-          menu.addItem((item) => {
-            item
-              .setTitle('Ingest folder into graph')
-              .setIcon('layers')
-              .onClick(() => {
-                void this.batchIngestFolder(file)
-              })
-          })
-          menu.addItem((item) => {
-            item
-              .setTitle('Remove folder from graph')
-              .setIcon('trash-2')
-              .onClick(() => {
-                void this.batchRemoveFolderFromGraph(file)
-              })
-          })
+          const inGraph = this.isFolderInGraph(file.path)
+          const showIngest = !this.ingestedFolderPathsLoaded || !inGraph
+          const showRemove = !this.ingestedFolderPathsLoaded || inGraph
+
+          if (showIngest) {
+            menu.addItem((item) => {
+              item
+                .setTitle('Ingest folder into graph')
+                .setIcon('layers')
+                .onClick(() => {
+                  void this.batchIngestFolder(file)
+                })
+            })
+          }
+          if (showRemove) {
+            menu.addItem((item) => {
+              item
+                .setTitle('Remove folder from graph')
+                .setIcon('trash-2')
+                .onClick(() => {
+                  void this.batchRemoveFolderFromGraph(file)
+                })
+            })
+          }
         }
       }),
     )
@@ -842,6 +870,43 @@ export default class NeuralComposerPlugin extends Plugin {
     return files
   }
 
+  /**
+   * Re-fetch the set of vault folders that contain ingested documents from
+   * /documents/paginated. Cheap (one HTTP roundtrip per ~200 docs) and only
+   * called on plugin load + after batch ingest/remove finishes.
+   */
+  async refreshIngestedFolderPaths(): Promise<void> {
+    try {
+      const ragEngine = await this.getRAGEngine()
+      const paths = await ragEngine.listAllDocumentPaths()
+      const folders = new Set<string>()
+      for (const filePath of paths) {
+        // Walk up the path: 'a/b/c.md' → add 'a/b' and 'a'.
+        const normalized = filePath.replace(/\\/g, '/')
+        const parts = normalized.split('/')
+        for (let i = parts.length - 1; i > 0; i--) {
+          folders.add(parts.slice(0, i).join('/'))
+        }
+      }
+      this.ingestedFolderPaths = folders
+      this.ingestedFolderPathsLoaded = true
+    } catch (e) {
+      console.error('refreshIngestedFolderPaths failed:', e)
+      // Keep ingestedFolderPathsLoaded=false so the menu falls back to
+      // showing both items.
+    }
+  }
+
+  /**
+   * True when the folder (or any of its descendants) has at least one
+   * document currently in the LightRAG graph. Synchronous — reads only
+   * from the in-memory cache populated by refreshIngestedFolderPaths.
+   */
+  private isFolderInGraph(folderPath: string): boolean {
+    if (!this.ingestedFolderPathsLoaded) return false
+    return this.ingestedFolderPaths.has(folderPath)
+  }
+
   async batchIngestFolder(folder: TFolder) {
     const files = this.getAllSupportedFiles(folder)
     if (files.length === 0) {
@@ -888,6 +953,9 @@ export default class NeuralComposerPlugin extends Plugin {
         `Uploaded files (${successCount}).\nStart processing...`,
       )
       await this.monitorPipeline(notice)
+      // Pick up the new files so the next folder right-click shows the
+      // correct (Ingest vs Remove) item.
+      void this.refreshIngestedFolderPaths()
     } catch (error) {
       console.error('Batch error:', error)
       notice.setMessage('Error starting upload.')
@@ -959,6 +1027,12 @@ export default class NeuralComposerPlugin extends Plugin {
           console.error(`Error removing ${file.name}:`, err)
           missing++
         }
+      }
+
+      // Pick up the new state so the next folder right-click shows the
+      // correct (Ingest vs Remove) item.
+      if (removed > 0) {
+        void this.refreshIngestedFolderPaths()
       }
 
       notice.setMessage(
@@ -1851,6 +1925,12 @@ export default class NeuralComposerPlugin extends Plugin {
         // Store the server version (core_version is canonical; api_version as fallback)
         this.setServerVersion(data?.core_version ?? data?.api_version ?? null)
         this.updateStatusUI(isBusy ? 'busy' : 'online')
+        // First health-check after the server came online — pre-populate the
+        // ingested-folders cache so the folder context menu can immediately
+        // show the right item.
+        if (!this.ingestedFolderPathsLoaded) {
+          void this.refreshIngestedFolderPaths()
+        }
       } else {
         this.setServerVersion(null)
         this.updateStatusUI('offline')


### PR DESCRIPTION
## Summary

Two related changes to the folder right-click menu:

### 1. New action — "Remove folder from graph"

Bulk-removes every ingested document under a folder (recursive) from the LightRAG graph. Sits next to the existing **Ingest folder into graph** item.

- Confirm modal before any delete, with the file count and a reminder that the files themselves stay in the vault.
- Iterates supported files via the existing `getAllSupportedFiles()` helper (same set used by batch ingest), calls the existing `ragEngine.deleteDocumentByFilePath()` per file, and shows a running progress notice.
- For files inside the configured **Watched folder**, also marks them as `removed` in `docIndexService` so the file-explorer status dots flip blue and the next file-change event doesn't auto-reingest them.
- Files that were never ingested return success-false from LightRAG and are counted as "not in graph" in the final notice — no failure is reported in that case.

### 2. Smart menu — show exactly one of the two items

Instead of always showing both, the menu now shows only the relevant action based on whether the folder has any descendants currently in the graph:

| Folder state | Menu shows |
|---|---|
| No descendants in the graph | "Ingest folder into graph" only |
| Has at least one ingested descendant | "Remove folder from graph" only |
| Cache not loaded (server unreachable on startup) | Both items, as fallback |

Works for **any** folder, not just the Watched folder.

Implementation:
- `ragEngine.listAllDocumentPaths()` — new helper that paginates `/documents/paginated` (200 docs per page, hard-capped at 200 pages) and returns every known `file_path`. Returns empty on transport / auth failure so callers can treat "I don't know" the same as "no data".
- `plugin.ingestedFolderPaths: Set<string>` — every ancestor folder path containing at least one ingested document. Built from the path list: `'Quotes/Author/Book/note.md'` contributes `'Quotes/Author/Book'`, `'Quotes/Author'`, and `'Quotes'`.
- `plugin.isFolderInGraph(folderPath)` — synchronous O(1) lookup used by the menu handler. Reading from an in-memory set keeps right-clicks snappy.
- Cache is refreshed (a) on the first health check that succeeds after plugin load, and (b) after `batchIngestFolder` / `executeBatchRemoveFolderFromGraph` finishes so the next right-click reflects the new state.

## Why

Today the plugin lets you remove a single file from the graph (right-click → "Remove from graph", only inside the Watched folder). Removing a whole subtree meant clicking through every file. This adds the natural bulk equivalent — and avoids cluttering the right-click menu with the item that doesn't apply.

## Test plan

- [x] Right-click a folder with **no** ingested descendants → only "Ingest" appears
- [x] Right-click a folder with **some** ingested descendants → only "Remove" appears
- [x] Right-click after server was offline at startup → both items appear; ingesting/removing once causes the next right-click to reflect the new state
- [x] After clicking "Remove" → confirm modal shows correct file count → "Remove" → notice shows `Removed N (M not in graph)`
- [x] Files inside the Watched folder flip to a blue dot in the file explorer after removal
- [x] Cancel button in the confirm modal aborts without deleting anything
- [x] Empty folder shows the "Empty folder or no supported files" notice instead of opening the modal