### PR TITLE
Change API key header from Authorization to X-API-Key

### DIFF
--- a/src/core/rag/docIndexService.ts
+++ b/src/core/rag/docIndexService.ts
@@ -198,7 +198,7 @@ export class DocIndexService {
   private getHeaders(): Record<string, string> {
     const h: Record<string, string> = { 'Content-Type': 'application/json' }
     if (this.plugin.settings.lightRagApiKey) {
-      h['Authorization'] = `Bearer ${this.plugin.settings.lightRagApiKey}`
+      h['X-API-Key'] = this.plugin.settings.lightRagApiKey
     }
     return h
   }

--- a/src/core/rag/ragEngine.ts
+++ b/src/core/rag/ragEngine.ts
@@ -93,7 +93,7 @@ export class RAGEngine {
   ): Record<string, string> {
     const headers: Record<string, string> = { 'Content-Type': contentType }
     if (this.settings.lightRagApiKey) {
-      headers['Authorization'] = `Bearer ${this.settings.lightRagApiKey}`
+      headers['X-API-Key'] = this.settings.lightRagApiKey
     }
     return headers
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -204,7 +204,7 @@ export default class NeuralComposerPlugin extends Plugin {
   private getLightRagHeaders(): Record<string, string> {
     const headers: Record<string, string> = {}
     if (this.settings.lightRagApiKey) {
-      headers['Authorization'] = `Bearer ${this.settings.lightRagApiKey}`
+      headers['X-API-Key'] = this.settings.lightRagApiKey
     }
     return headers
   }
@@ -1272,7 +1272,7 @@ export default class NeuralComposerPlugin extends Plugin {
         url,
         method: 'POST',
         headers: this.settings.lightRagApiKey
-          ? { Authorization: `Bearer ${this.settings.lightRagApiKey}` }
+          ? { 'X-API-Key': this.settings.lightRagApiKey }
           : {},
         throw: false,
       })

--- a/src/views/NativeGraphView.ts
+++ b/src/views/NativeGraphView.ts
@@ -322,7 +322,7 @@ export class NativeGraphView extends ItemView {
   private getLightRagHeaders(): Record<string, string> {
     const headers: Record<string, string> = {}
     if (this.plugin.settings.lightRagApiKey) {
-      headers['Authorization'] = `Bearer ${this.plugin.settings.lightRagApiKey}`
+      headers['X-API-Key'] = this.plugin.settings.lightRagApiKey
     }
     return headers
   }
@@ -1077,7 +1077,7 @@ export class NativeGraphView extends ItemView {
         headers: {
           'Content-Type': 'application/json',
           ...(this.plugin.settings.lightRagApiKey
-            ? { Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}` }
+            ? { 'X-API-Key': this.plugin.settings.lightRagApiKey }
             : {}),
         },
         body: JSON.stringify({
@@ -1412,7 +1412,7 @@ export class NativeGraphView extends ItemView {
               'Content-Type': 'application/json',
               ...(this.plugin.settings.lightRagApiKey
                 ? {
-                    Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}`,
+                    'X-API-Key': this.plugin.settings.lightRagApiKey,
                   }
                 : {}),
             },
@@ -1457,7 +1457,7 @@ export class NativeGraphView extends ItemView {
                 'Content-Type': 'application/json',
                 ...(this.plugin.settings.lightRagApiKey
                   ? {
-                      Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}`,
+                      'X-API-Key': this.plugin.settings.lightRagApiKey,
                     }
                   : {}),
               },
@@ -1547,7 +1547,7 @@ export class NativeGraphView extends ItemView {
                 'Content-Type': 'application/json',
                 ...(this.plugin.settings.lightRagApiKey
                   ? {
-                      Authorization: `Bearer ${this.plugin.settings.lightRagApiKey}`,
+                      'X-API-Key': this.plugin.settings.lightRagApiKey,
                     }
                   : {}),
               },


### PR DESCRIPTION
## Description

Fixes LightRAG authentication header for remote server connections. Changes `Authorization: Bearer <key>` to `X-API-Key: <key>` in all locations where the LightRAG API key is sent, resolving 401 "Invalid token" errors when connecting to a LightRAG server protected by `LIGHTRAG_API_KEY`.

Fixes bug #37 

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually
