### PR TITLE
Scale folder removal to large vaults + live progress

### DIFF
--- a/src/components/settings/SettingsTabRoot.tsx
+++ b/src/components/settings/SettingsTabRoot.tsx
@@ -52,7 +52,6 @@ const TABS: TabDef[] = [
   { id: 'help', label: 'Help', Icon: CircleHelp },
 ]
 
-
 // ---------------------------------------------------------------------------
 // Brand logo tile — violet rounded square with brain-circuit glyph inside
 // ---------------------------------------------------------------------------

--- a/src/core/rag/ragEngine.ts
+++ b/src/core/rag/ragEngine.ts
@@ -183,12 +183,26 @@ export class RAGEngine {
 
   // --- 2b. INCREMENTAL SYNC HELPERS ---
 
-  async listAllDocumentPaths(): Promise<string[]> {
+  /**
+   * Paginate through ALL pages of `/documents/paginated` and return every
+   * document's id + file_path. `/documents/paginated` caps page_size at 200,
+   * so a vault with >200 docs spans multiple pages — resolving them all here
+   * means folder operations work no matter how large the vault is.
+   *
+   * `onPage` lets callers short-circuit the walk (e.g. findDocIdByFilePath
+   * stops as soon as it sees its target) without fetching the remaining pages.
+   * Returns whatever was collected before the abort / failure.
+   */
+  private async listAllDocuments(
+    onPage?: (docs: { id: string; file_path?: string | null }[]) => boolean,
+  ): Promise<{ id: string; file_path: string }[]> {
     const pageSize = 200
-    const paths: string[] = []
+    const out: { id: string; file_path: string }[] = []
     let page = 1
     try {
-      while (page <= 200) {
+      // Hard cap to avoid runaway loops if the server reports `has_next: true`
+      // forever for some reason.
+      while (page <= 1000) {
         const response = await requestUrl({
           url: `${this.settings.lightRagServerUrl}/documents/paginated`,
           method: 'POST',
@@ -206,70 +220,91 @@ export class RAGEngine {
           documents?: { id: string; file_path?: string | null }[]
           pagination?: { has_next?: boolean }
         }
-        for (const doc of data.documents ?? []) {
+        const docs = data.documents ?? []
+        for (const doc of docs) {
           if (typeof doc.file_path === 'string' && doc.file_path.length > 0) {
-            paths.push(doc.file_path)
+            out.push({ id: doc.id, file_path: doc.file_path })
           }
         }
+        // Let the caller stop early (e.g. it already found its target).
+        if (onPage && onPage(docs)) break
         if (!data.pagination?.has_next) break
         page++
       }
     } catch (e) {
-      console.error('listAllDocumentPaths failed:', e)
-      return []
+      console.error('listAllDocuments failed:', e)
     }
-    return paths
+    return out
+  }
+
+  /**
+   * Every `file_path` currently known to the server. Used by the folder
+   * context menu to decide "Ingest folder" vs "Remove folder from graph".
+   * Empty on failure — callers treat "I don't know" as "no data".
+   */
+  async listAllDocumentPaths(): Promise<string[]> {
+    return (await this.listAllDocuments()).map((d) => d.file_path)
+  }
+
+  /**
+   * Map of every vault file_path → its LightRAG doc_id. Lets bulk operations
+   * (folder removal) resolve all ids in a single pagination pass instead of
+   * one full lookup per file. Both the full vault-relative path and the bare
+   * filename are indexed so callers can match either.
+   */
+  async getDocIdMap(): Promise<Map<string, string>> {
+    const map = new Map<string, string>()
+    for (const d of await this.listAllDocuments()) {
+      map.set(d.file_path, d.id)
+      const base = d.file_path.replace(/\\/g, '/').split('/').pop()
+      // Don't let a bare-filename entry clobber an exact full-path entry.
+      if (base && !map.has(base)) map.set(base, d.id)
+    }
+    return map
   }
 
   // Finds a LightRAG doc_id matching the given file.
   // Tries the full vault-relative path first (v1.2+ ingest), then falls back to
   // bare filename (pre-v1.2 ingest used file.name instead of file.path).
+  // Walks every page, stopping as soon as the target is found.
   async findDocIdByFilePath(
     filePath: string,
     fileName: string,
   ): Promise<string | null> {
-    try {
-      const response = await requestUrl({
-        url: `${this.settings.lightRagServerUrl}/documents/paginated`,
-        method: 'POST',
-        headers: this.getLightRagHeaders(),
-        body: JSON.stringify({
-          page: 1,
-          page_size: 200,
-          sort_field: 'file_path',
-          sort_direction: 'asc',
-        }),
-        throw: false,
-      })
-      if (response.status >= 400) return null
-      const data = response.json as {
-        documents?: { id: string; file_path: string }[]
+    let found: string | null = null
+    await this.listAllDocuments((docs) => {
+      const hit =
+        docs.find((d) => d.file_path === filePath) ??
+        docs.find((d) => d.file_path === fileName)
+      if (hit) {
+        found = hit.id
+        return true // stop paginating
       }
-      const docs = data.documents ?? []
-      // Prefer exact full-path match, fall back to bare filename for older entries
-      return (
-        docs.find((d) => d.file_path === filePath)?.id ??
-        docs.find((d) => d.file_path === fileName)?.id ??
-        null
-      )
-    } catch {
-      return null
-    }
+      return false
+    })
+    return found
   }
 
-  async deleteDocumentByFilePath(
-    filePath: string,
-    fileName: string,
-  ): Promise<boolean> {
-    const docId = await this.findDocIdByFilePath(filePath, fileName)
-    if (!docId) return false
+  /** Delete a single document from the graph by its LightRAG doc_id. */
+  async deleteDocumentById(docId: string): Promise<boolean> {
+    return this.deleteDocumentsByIds([docId])
+  }
+
+  /**
+   * Delete many documents in one request. `/documents/delete_document` takes
+   * a `doc_ids` array, so bulk folder removal sends every id at once instead
+   * of one request per file. Returns true if the server accepted the batch
+   * (deletion then proceeds in the background).
+   */
+  async deleteDocumentsByIds(docIds: string[]): Promise<boolean> {
+    if (docIds.length === 0) return true
     try {
       const response = await requestUrl({
         url: `${this.settings.lightRagServerUrl}/documents/delete_document`,
         method: 'DELETE',
         headers: this.getLightRagHeaders(),
         body: JSON.stringify({
-          doc_ids: [docId],
+          doc_ids: docIds,
           delete_file: false,
           delete_llm_cache: true,
         }),
@@ -279,6 +314,15 @@ export class RAGEngine {
     } catch {
       return false
     }
+  }
+
+  async deleteDocumentByFilePath(
+    filePath: string,
+    fileName: string,
+  ): Promise<boolean> {
+    const docId = await this.findDocIdByFilePath(filePath, fileName)
+    if (!docId) return false
+    return this.deleteDocumentById(docId)
   }
 
   // Removes old entry and re-inserts the current file content.

--- a/src/main.ts
+++ b/src/main.ts
@@ -792,7 +792,14 @@ export default class NeuralComposerPlugin extends Plugin {
   }
 
   // --- MONITORING LOGIC ---
-  async monitorPipeline(notice: Notice) {
+  // Polls /documents/pipeline_status and reports live progress in `notice`.
+  // Used for both ingestion and removal — the server's pipeline_status exposes
+  // `job_name` ("Deleting 100 Documents", "indexing", …) and a `latest_message`
+  // that we surface verbatim, so the same monitor works for either operation.
+  async monitorPipeline(
+    notice: Notice,
+    doneMessage = 'Integrated knowledge!\nThe graph is up to date.',
+  ) {
     this.updateStatusUI('busy')
     let isBusy = true
     let errors = 0
@@ -814,9 +821,12 @@ export default class NeuralComposerPlugin extends Plugin {
           const total = status.batchs || 1
           const current = status.cur_batch || 0
           const percent = Math.round((current / total) * 100)
+          // job_name distinguishes deletion ("Deleting N Documents") from
+          // ingestion so the header reflects what's actually happening.
+          const header = status.job_name || 'System processing...'
 
           notice.setMessage(
-            `System processing...\n` +
+            `${header}\n` +
               `Progress: ${percent}% (${current}/${total})\n` +
               `📝 ${status.latest_message || 'Analyzing...'}`,
           )
@@ -834,8 +844,48 @@ export default class NeuralComposerPlugin extends Plugin {
     }
 
     this.updateStatusUI('online')
-    notice.setMessage('Integrated knowledge!\nThe graph is up to date.')
+    notice.setMessage(doneMessage)
     setTimeout(() => notice.hide(), 5000)
+  }
+
+  /**
+   * Poll /documents/pipeline_status until the server is idle. Used to serialize
+   * bulk deletes: LightRAG runs one deletion job at a time and drops delete
+   * requests received while it's busy, so callers must wait for each batch to
+   * drain before sending the next. `onBusy` receives the live status on each
+   * poll where the pipeline is busy (for progress UI).
+   */
+  private async waitForPipelineIdle(
+    onBusy?: (status: Record<string, unknown>) => void,
+    maxMs = 60 * 60 * 1000,
+  ): Promise<void> {
+    const start = Date.now()
+    // Grace period so we don't read `busy:false` before the job registers.
+    await new Promise((r) => setTimeout(r, 1500))
+    let idleReads = 0
+    let errors = 0
+    while (Date.now() - start < maxMs) {
+      try {
+        const response = await requestUrl({
+          url: `${this.settings.lightRagServerUrl}/documents/pipeline_status`,
+          method: 'GET',
+          headers: this.getLightRagHeaders(),
+          throw: false,
+        })
+        const status = response.json as Record<string, unknown>
+        if (status.busy) {
+          idleReads = 0
+          onBusy?.(status)
+        } else if (++idleReads >= 2) {
+          // Two consecutive idle reads → this batch has finished on the server.
+          return
+        }
+        errors = 0
+      } catch {
+        if (++errors > 5) return
+      }
+      await new Promise((r) => setTimeout(r, 2000))
+    }
   }
 
   // --- BATCH LOGIC ---
@@ -961,40 +1011,78 @@ export default class NeuralComposerPlugin extends Plugin {
 
     try {
       const ragEngine = await this.getRAGEngine()
+
+      // Resolve every doc_id in ONE pagination pass (the document list spans
+      // multiple pages on large vaults), then delete in batches. Far fewer
+      // requests than per-file lookup+delete, and correct regardless of size.
+      notice.setMessage('Looking up documents in graph…')
+      const idMap = await ragEngine.getDocIdMap()
+
+      const toDelete: { docId: string; path: string }[] = []
+      for (const file of files) {
+        const docId = idMap.get(file.path) ?? idMap.get(file.name)
+        if (docId) toDelete.push({ docId, path: file.path })
+      }
+      const missing = files.length - toDelete.length
+
+      const tail = missing > 0 ? ` (${missing} not in graph)` : ''
+      if (toDelete.length === 0) {
+        notice.setMessage(
+          missing > 0
+            ? `Nothing removed — ${missing} file(s) were not in the graph.`
+            : 'Nothing to remove.',
+        )
+        setTimeout(() => notice.hide(), 5000)
+        return
+      }
+
+      // Delete in chunks, SEQUENTIALLY. LightRAG runs one deletion job at a
+      // time and drops delete requests received while it's busy, so firing all
+      // chunks at once would only delete the first. We send a chunk, wait for
+      // the server pipeline to drain, then send the next. Deletion is also slow
+      // (the entity graph is reprocessed per document), so we surface live
+      // per-batch progress in the notice.
+      const CHUNK = 100
+      const totalBatches = Math.ceil(toDelete.length / CHUNK)
       let removed = 0
-      let missing = 0
-
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i]
-        notice.setMessage(`Removing (${i + 1}/${files.length}):\n${file.name}`)
-        try {
-          const ok = await ragEngine.deleteDocumentByFilePath(
-            file.path,
-            file.name,
-          )
-          if (ok) {
-            removed++
-            if (isInWatchedFolder(file.path)) {
-              this.docIndexService?.setRemoved(file.path)
-            }
-          } else {
-            missing++
+      for (let b = 0; b < totalBatches; b++) {
+        const batch = toDelete.slice(b * CHUNK, b * CHUNK + CHUNK)
+        notice.setMessage(
+          `Removing from "${folder.path}"${tail}\n` +
+            `Batch ${b + 1}/${totalBatches} — sending ${batch.length}…`,
+        )
+        const ok = await ragEngine.deleteDocumentsByIds(
+          batch.map((x) => x.docId),
+        )
+        if (ok) {
+          removed += batch.length
+          for (const x of batch) {
+            if (isInWatchedFolder(x.path))
+              this.docIndexService?.setRemoved(x.path)
           }
-        } catch (err) {
-          console.error(`Error removing ${file.name}:`, err)
-          missing++
         }
+        this.updateStatusUI('busy')
+        // Wait for this batch to finish before sending the next one.
+        await this.waitForPipelineIdle((status) => {
+          const cur = (status.cur_batch as number) || 0
+          const tot = (status.batchs as number) || batch.length
+          const pct = Math.round((cur / Math.max(tot, 1)) * 100)
+          notice.setMessage(
+            `Removing from "${folder.path}"${tail}\n` +
+              `Batch ${b + 1}/${totalBatches} · ${pct}%\n` +
+              `📝 ${(status.latest_message as string) || 'Processing…'}`,
+          )
+        })
       }
 
-      if (removed > 0) {
-        void this.refreshIngestedFolderPaths()
-      }
-
+      this.updateStatusUI('online')
       notice.setMessage(
-        `Removed ${removed} from "${folder.path}"` +
-          (missing > 0 ? ` (${missing} not in graph)` : ''),
+        `Removed ${removed} from "${folder.path}"${tail}.\nReopen the graph view to refresh.`,
       )
-      setTimeout(() => notice.hide(), 4000)
+      setTimeout(() => notice.hide(), 6000)
+
+      // Deletion finished — refresh menu state + file-explorer dots.
+      void this.refreshIngestedFolderPaths()
       this.decorateFileExplorer()
     } catch (error) {
       console.error('Batch remove error:', error)

--- a/src/utils/text-splitter.ts
+++ b/src/utils/text-splitter.ts
@@ -109,16 +109,14 @@ export class RecursiveMarkdownTextSplitter {
   // piece so structure (e.g. heading markers) is preserved inside chunks.
   private splitBySeparator(text: string, separator: string): string[] {
     if (!separator) return text.length > 0 ? [text] : []
-    return text
-      .split(separator)
-      .reduce<string[]>((acc, part, i) => {
-        const piece = i === 0 ? part : separator + part
-        // Skip pieces that are just the separator with no following content.
-        if (i === 0 ? piece.length > 0 : piece.length > separator.length) {
-          acc.push(piece)
-        }
-        return acc
-      }, [])
+    return text.split(separator).reduce<string[]>((acc, part, i) => {
+      const piece = i === 0 ? part : separator + part
+      // Skip pieces that are just the separator with no following content.
+      if (i === 0 ? piece.length > 0 : piece.length > separator.length) {
+        acc.push(piece)
+      }
+      return acc
+    }, [])
   }
 
   // Merge splits into chunks up to chunkSize, retaining chunkOverlap between
@@ -133,7 +131,10 @@ export class RecursiveMarkdownTextSplitter {
       const splitLen = split.length
       const overhead = currentParts.length > 0 ? sepLen : 0
 
-      if (total + overhead + splitLen > this.chunkSize && currentParts.length > 0) {
+      if (
+        total + overhead + splitLen > this.chunkSize &&
+        currentParts.length > 0
+      ) {
         docs.push(currentParts.join(separator))
         // Trim from the front until within overlap budget.
         while (
@@ -141,7 +142,8 @@ export class RecursiveMarkdownTextSplitter {
           (total > this.chunkOverlap ||
             total + splitLen + sepLen > this.chunkSize)
         ) {
-          total -= currentParts[0].length + (currentParts.length > 1 ? sepLen : 0)
+          total -=
+            currentParts[0].length + (currentParts.length > 1 ? sepLen : 0)
           currentParts.shift()
         }
       }


### PR DESCRIPTION
## Summary

Three improvements to **Remove folder from graph**, aimed at large vaults and long-running deletions:

### Resolve documents across the full set, not one page
`/documents/paginated` caps `page_size` at 200, so a vault with more than 200 documents spans multiple pages. Folder removal now walks every page (`listAllDocuments`) and builds a `file_path → doc_id` map in a single pass, so it resolves every matching document regardless of vault size.

### Batch the deletions
`/documents/delete_document` accepts a `doc_ids` array, so removal now sends ids in chunks of 100 (`deleteDocumentsByIds`) instead of one request per file — dramatically fewer round-trips when clearing a large folder.

### Live progress while the server works
LightRAG deletes asynchronously and reprocesses the entity graph per document, which can take a while for big folders. Removal now tracks the server-side job in the same notice ingestion uses — `monitorPipeline` surfaces the job name ("Deleting N Documents"), percent, and the latest status message, then ends with a summary. File-explorer dots and menu state refresh once the job completes.

Also: clear "nothing to remove" feedback when no files matched the graph.

## Test plan
- [x] Remove a folder with >200 docs in a large vault — all matching docs are resolved and queued