### PR TITLE
fix: render inline LaTeX math in chat view

### DIFF
--- a/src/components/chat-view/AssistantMessageContent.tsx
+++ b/src/components/chat-view/AssistantMessageContent.tsx
@@ -2,6 +2,7 @@ import { Check } from 'lucide-react'
 import React, { useCallback, useMemo, useState, useEffect } from 'react'
 
 import { ChatAssistantMessage, ChatMessage } from '../../types/chat'
+import { formatAssistantMarkdown } from '../../utils/chat/format-assistant-markdown'
 import {
   ParsedTagContent,
   parseTagContents,
@@ -117,7 +118,10 @@ const AssistantTextRenderer = React.memo(function AssistantTextRenderer({
       {blocks.map((block, index) =>
         block.type === 'string' ? (
           <div key={index}>
-            <ObsidianMarkdown content={block.content} scale="sm" />
+            <ObsidianMarkdown
+              content={formatAssistantMarkdown(block.content)}
+              scale="sm"
+            />
           </div>
         ) : block.type === 'think' ? (
           <AssistantMessageReasoning key={index} reasoning={block.content} />

--- a/src/components/chat-view/AssistantMessageReasoning.tsx
+++ b/src/components/chat-view/AssistantMessageReasoning.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { memo, useEffect, useRef, useState } from 'react'
 
+import { formatAssistantMarkdown } from '../../utils/chat/format-assistant-markdown'
 import DotLoader from '../common/DotLoader'
 
 import { ObsidianMarkdown } from './ObsidianMarkdown'
@@ -52,7 +53,10 @@ const AssistantMessageReasoning = memo(function AssistantMessageReasoning({
       </div>
       {isExpanded && (
         <div className="nrlcmp-assistant-message-metadata-content">
-          <ObsidianMarkdown content={reasoning} scale="xs" />
+          <ObsidianMarkdown
+            content={formatAssistantMarkdown(reasoning)}
+            scale="xs"
+          />
         </div>
       )}
     </div>

--- a/src/utils/chat/format-assistant-markdown.ts
+++ b/src/utils/chat/format-assistant-markdown.ts
@@ -1,0 +1,23 @@
+import { normalizeMathDelimiters } from './normalize-math'
+
+/**
+ * Central formatter for assistant-generated markdown before it is handed to
+ * Obsidian's MarkdownRenderer.
+ *
+ * LLM output often needs light normalization so that it renders the way users
+ * expect inside Obsidian (e.g. converting LaTeX-style math delimiters into the
+ * `$...$` / `$$...$$` form Obsidian understands). Keeping these transforms in a
+ * single pipeline means every assistant render path stays consistent and future
+ * cleaners only need to be registered here.
+ *
+ * Note: this is intended for assistant *prose*. Do not run it over raw code
+ * blocks or file reference previews, where the content should be shown verbatim.
+ */
+const transforms: ((content: string) => string)[] = [normalizeMathDelimiters]
+
+export function formatAssistantMarkdown(content: string): string {
+  return transforms.reduce(
+    (formatted, transform) => transform(formatted),
+    content,
+  )
+}

--- a/src/utils/chat/normalize-math.test.ts
+++ b/src/utils/chat/normalize-math.test.ts
@@ -1,0 +1,62 @@
+import { normalizeMathDelimiters } from './normalize-math'
+
+describe('normalizeMathDelimiters', () => {
+  it('converts inline LaTeX delimiters to Obsidian delimiters', () => {
+    expect(
+      normalizeMathDelimiters('The value \\(x^2 + 1\\) is positive.'),
+    ).toBe('The value $x^2 + 1$ is positive.')
+  })
+
+  it('converts block LaTeX delimiters to Obsidian delimiters', () => {
+    expect(normalizeMathDelimiters('\\[E = mc^2\\]')).toBe('$$E = mc^2$$')
+  })
+
+  it('converts multiline block math', () => {
+    const input = '\\[\na^2 + b^2 = c^2\n\\]'
+    expect(normalizeMathDelimiters(input)).toBe('$$\na^2 + b^2 = c^2\n$$')
+  })
+
+  it('handles multiple math expressions in one string', () => {
+    const input = 'First \\(a\\) then \\(b\\) and finally \\[c\\].'
+    expect(normalizeMathDelimiters(input)).toBe(
+      'First $a$ then $b$ and finally $$c$$.',
+    )
+  })
+
+  it('leaves content without LaTeX delimiters unchanged', () => {
+    const input = 'Just some text with $existing$ math and no conversions.'
+    expect(normalizeMathDelimiters(input)).toBe(input)
+  })
+
+  it('does not convert delimiters inside inline code spans', () => {
+    const input = 'Use `\\(x\\)` to write inline math.'
+    expect(normalizeMathDelimiters(input)).toBe(input)
+  })
+
+  it('does not convert delimiters inside fenced code blocks', () => {
+    const input = ['```latex', '\\(x^2\\)', '\\[y^2\\]', '```'].join('\n')
+    expect(normalizeMathDelimiters(input)).toBe(input)
+  })
+
+  it('converts prose around code blocks but not inside them', () => {
+    const input = [
+      'Inline \\(a\\) before.',
+      '```',
+      '\\(b\\)',
+      '```',
+      'After \\(c\\).',
+    ].join('\n')
+    const expected = [
+      'Inline $a$ before.',
+      '```',
+      '\\(b\\)',
+      '```',
+      'After $c$.',
+    ].join('\n')
+    expect(normalizeMathDelimiters(input)).toBe(expected)
+  })
+
+  it('preserves inner whitespace of the math expression', () => {
+    expect(normalizeMathDelimiters('\\( x + y \\)')).toBe('$ x + y $')
+  })
+})

--- a/src/utils/chat/normalize-math.ts
+++ b/src/utils/chat/normalize-math.ts
@@ -1,0 +1,57 @@
+/**
+ * Obsidian renders math via MathJax, but only recognizes the `$...$` (inline)
+ * and `$$...$$` (block) delimiters. LLMs, however, commonly emit LaTeX using the
+ * `\( ... \)` (inline) and `\[ ... \]` (block) delimiters. As a result, math in
+ * assistant messages is shown as raw text instead of being rendered.
+ *
+ * This utility rewrites the LaTeX-style delimiters into the Obsidian-style
+ * delimiters so that Obsidian's MarkdownRenderer renders the math properly.
+ *
+ * Code spans (`` `...` ``) and fenced code blocks (``` ``` ``` ```) are left
+ * untouched so that LaTeX delimiters appearing inside code are preserved as-is.
+ */
+
+// Matches fenced code blocks (``` or ~~~) and inline code spans so we can skip
+// over them while converting the surrounding prose.
+const CODE_SEGMENT_REGEX = /(```[\s\S]*?```|~~~[\s\S]*?~~~|`+[^`\n]*?`+)/g
+
+function convertDelimiters(text: string): string {
+  return (
+    text
+      // Block math: \[ ... \] -> $$ ... $$
+      .replace(/\\\[([\s\S]*?)\\\]/g, (_match, inner: string) => `$$${inner}$$`)
+      // Inline math: \( ... \) -> $ ... $
+      .replace(/\\\(([\s\S]*?)\\\)/g, (_match, inner: string) => `$${inner}$`)
+  )
+}
+
+/**
+ * Converts LaTeX-style math delimiters (`\(...\)`, `\[...\]`) to the
+ * Obsidian-style delimiters (`$...$`, `$$...$$`) outside of code regions.
+ *
+ * @param content - The raw markdown content (e.g. an assistant message).
+ * @returns The content with math delimiters normalized for Obsidian.
+ */
+export function normalizeMathDelimiters(content: string): string {
+  if (!content.includes('\\(') && !content.includes('\\[')) {
+    return content
+  }
+
+  let result = ''
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  CODE_SEGMENT_REGEX.lastIndex = 0
+  while ((match = CODE_SEGMENT_REGEX.exec(content)) !== null) {
+    // Convert the prose preceding this code segment.
+    result += convertDelimiters(content.slice(lastIndex, match.index))
+    // Preserve the code segment verbatim.
+    result += match[0]
+    lastIndex = match.index + match[0].length
+  }
+
+  // Convert any remaining prose after the last code segment.
+  result += convertDelimiters(content.slice(lastIndex))
+
+  return result
+}


### PR DESCRIPTION
Closes #40

## Summary

Obsidian renders math via MathJax, but `MarkdownRenderer` only recognizes the `$...$` / `$$...$$` delimiters. LLMs commonly emit LaTeX using `\( ... \)` and `\[ ... \]`, so math in assistant messages was displayed as raw text instead of being rendered.

This PR normalizes the LaTeX-style delimiters to Obsidian-style delimiters before rendering.

## Changes

- Add `normalizeMathDelimiters` ([src/utils/chat/normalize-math.ts](src/utils/chat/normalize-math.ts)) that rewrites `\(...\)` → `$...$` and `\[...\]` → `$$...$$`. Inline code spans and fenced code blocks are left untouched so LaTeX shown inside code stays verbatim.
- Add a central `formatAssistantMarkdown` pipeline ([src/utils/chat/format-assistant-markdown.ts](src/utils/chat/format-assistant-markdown.ts)) so every assistant render path is formatted consistently and future cleaners only need to be registered in one place.
- Route assistant message prose and reasoning through the formatter ([AssistantMessageContent.tsx](src/components/chat-view/AssistantMessageContent.tsx), [AssistantMessageReasoning.tsx](src/components/chat-view/AssistantMessageReasoning.tsx)). Code blocks and file-reference previews are intentionally **not** normalized.

## Testing

- New unit tests in [src/utils/chat/normalize-math.test.ts](src/utils/chat/normalize-math.test.ts) (inline, block, multiline, multiple expressions, code-span/fence protection, whitespace).
- `npm test` (130 passed) and `npm run type:check` pass. Prettier passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)