### PR TITLE
feat: exclude files/folders from graph (LightRAG) sync

### DIFF
--- a/src/components/settings/sections/NeuralSection.tsx
+++ b/src/components/settings/sections/NeuralSection.tsx
@@ -316,6 +316,48 @@ export const NeuralSection = ({ plugin }: { plugin: NeuralComposerPlugin }) => {
         new FolderSuggest(plugin.app, text.inputEl)
       })
 
+    new Setting(container)
+      .setName('Exclude hidden files and folders')
+      .setDesc(
+        'When enabled, files and folders whose name starts with a dot ' +
+          '(e.g. ".trash", ".obsidian") are never ingested into the graph.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(plugin.settings.lightRagExcludeHiddenFiles)
+          .onChange((value) => {
+            void plugin.setSettings({
+              ...plugin.settings,
+              lightRagExcludeHiddenFiles: value,
+            })
+          }),
+      )
+
+    new Setting(container)
+      .setName('Exclude patterns')
+      .setDesc(
+        'Glob patterns (one per line) for files inside the watched folder that ' +
+          'should never be ingested into the graph. Example: "Main/Templates/**". ' +
+          'You can also right-click a file or folder and choose "Exclude from graph sync".',
+      )
+      .addTextArea((textArea) => {
+        textArea
+          .setPlaceholder('Main/Templates/**\nMain/Inbox/scratch.md')
+          .setValue(plugin.settings.lightRagExcludePatterns.join('\n'))
+          .onChange((value) => {
+            const patterns = value
+              .split('\n')
+              .map((p) => p.trim())
+              .filter((p) => p.length > 0)
+            void plugin.setSettings({
+              ...plugin.settings,
+              lightRagExcludePatterns: patterns,
+            })
+          })
+        textArea.inputEl.rows = 4
+        textArea.inputEl.style.width = '100%'
+      })
+
     // --- ONTOLOGY SECTION ---
     container.createEl('h4', { text: 'Ontology (categories)' })
 

--- a/src/core/rag/ragEngine.ts
+++ b/src/core/rag/ragEngine.ts
@@ -5,6 +5,7 @@ import { VectorManager } from '../../database/modules/vector/VectorManager'
 import { SelectEmbedding } from '../../database/schema'
 import { NeuralComposerSettings } from '../../settings/schema/setting.types'
 import { EmbeddingModelClient } from '../../types/embedding'
+import { isExcludedFromGraphSync } from '../../utils/glob-utils'
 
 import { getEmbeddingModelClient } from './embedding'
 
@@ -289,6 +290,21 @@ export class RAGEngine {
 
   // Inserts a file into the index without deleting first.
   async ingestFile(file: TFile): Promise<boolean> {
+    // Safety net: never ingest files the user has excluded from graph sync.
+    // Callers gate excluded files earlier (before showing "processing"), so this
+    // mainly protects any future call site.
+    if (
+      isExcludedFromGraphSync(file.path, {
+        excludePatterns: this.settings.lightRagExcludePatterns,
+        excludeHiddenFiles: this.settings.lightRagExcludeHiddenFiles,
+      })
+    ) {
+      console.log(
+        `[NeuralComposer] Skipping excluded file (graph sync): ${file.path}`,
+      )
+      return false
+    }
+
     const ext = file.extension.toLowerCase()
     const textExts = ['md', 'txt', 'csv', 'json', 'html', 'htm', 'xml']
     if (textExts.includes(ext)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,10 @@ import {
 } from './settings/schema/setting.types'
 import { parseNeuralComposerSettings } from './settings/schema/settings'
 import { NeuralComposerSettingTab } from './settings/SettingTab'
+import {
+  getExcludePatternForPath,
+  isExcludedFromGraphSync,
+} from './utils/glob-utils'
 import { getMentionableBlockData } from './utils/obsidian'
 import { VectorManager } from './database/modules/vector/VectorManager'
 
@@ -370,6 +374,18 @@ export default class NeuralComposerPlugin extends Plugin {
       }),
     )
 
+    // --- CONTEXT MENU: exclude / re-include from graph sync (files & folders) ---
+    this.registerEvent(
+      this.app.workspace.on('file-menu', (menu, file) => {
+        this.addGraphExclusionMenuItem(menu, [file])
+      }),
+    )
+    this.registerEvent(
+      this.app.workspace.on('files-menu', (menu, files) => {
+        this.addGraphExclusionMenuItem(menu, files)
+      }),
+    )
+
     // --- SINGLE FILE INGEST COMMAND ---
     this.addCommand({
       id: 'ingest-current-file',
@@ -439,6 +455,7 @@ export default class NeuralComposerPlugin extends Plugin {
         if (!(file instanceof TFile)) return
         if (!isInSyncFolder(file.path)) return
         if (!SUPPORTED_EXTENSIONS.includes(file.extension.toLowerCase())) return
+        if (this.isPathExcludedFromGraph(file.path)) return
         // Guard here (before setTimeout) so startup create-events are dropped
         // before the 2 s timer is even scheduled. By the time the timer would
         // fire, onLayoutReady has already set docIndexReady = true, so the
@@ -513,7 +530,14 @@ export default class NeuralComposerPlugin extends Plugin {
           const ragEngine = await this.getRAGEngine()
 
           if (wasInFolder && nowInFolder) {
-            // Renamed or moved within the watched folder
+            // Renamed or moved within the watched folder.
+            // If the new path is now excluded, remove the old doc and stop.
+            if (this.isPathExcludedFromGraph(file.path)) {
+              const oldName = oldPath.split('/').pop() ?? oldPath
+              await ragEngine.deleteDocumentByFilePath(oldPath, oldName)
+              this.docIndexService?.removeEntry(oldPath)
+              return
+            }
             const notice = new Notice(
               `Graph sync: updating "${file.name}" in graph...`,
               0,
@@ -547,6 +571,7 @@ export default class NeuralComposerPlugin extends Plugin {
             setTimeout(() => notice.hide(), 6000)
           } else {
             // Moved INTO the watched folder
+            if (this.isPathExcludedFromGraph(file.path)) return
             const notice = new Notice(
               `Graph sync: sending "${file.name}"...`,
               0,
@@ -574,6 +599,7 @@ export default class NeuralComposerPlugin extends Plugin {
         if (!(file instanceof TFile)) return
         if (!isInSyncFolder(file.path)) return
         if (!SUPPORTED_EXTENSIONS.includes(file.extension.toLowerCase())) return
+        if (this.isPathExcludedFromGraph(file.path)) return
 
         // Debounce: wait 5 s of inactivity before re-indexing
         const existing = this.modifyDebounceMap.get(file.path)
@@ -853,8 +879,122 @@ export default class NeuralComposerPlugin extends Plugin {
     return files
   }
 
+  /**
+   * True if the given vault path is excluded from graph (LightRAG) ingestion,
+   * either by the user's exclude patterns or the "exclude hidden files" setting.
+   */
+  isPathExcludedFromGraph(path: string): boolean {
+    return isExcludedFromGraphSync(path, {
+      excludePatterns: this.settings.lightRagExcludePatterns,
+      excludeHiddenFiles: this.settings.lightRagExcludeHiddenFiles,
+    })
+  }
+
+  /**
+   * Adds an "Exclude from graph sync" (or "Re-include") item to the file
+   * explorer context menu for the given files/folders. Folders exclude all of
+   * their descendants.
+   */
+  private addGraphExclusionMenuItem(menu: Menu, files: TAbstractFile[]) {
+    if (files.length === 0) return
+
+    const patterns = files.map((file) =>
+      getExcludePatternForPath(file.path, file instanceof TFolder),
+    )
+    const current = this.settings.lightRagExcludePatterns
+    const allExcluded = patterns.every((pattern) => current.includes(pattern))
+
+    menu.addItem((item) => {
+      item
+        .setTitle(
+          allExcluded ? 'Re-include in graph sync' : 'Exclude from graph sync',
+        )
+        .setIcon(allExcluded ? 'eye' : 'eye-off')
+        .onClick(() => {
+          if (allExcluded) {
+            void this.removeGraphExcludePatterns(patterns)
+          } else {
+            void this.addGraphExclusionForFiles(files, patterns)
+          }
+        })
+    })
+  }
+
+  private async addGraphExclusionForFiles(
+    files: TAbstractFile[],
+    patterns: string[],
+  ) {
+    const merged = Array.from(
+      new Set([...this.settings.lightRagExcludePatterns, ...patterns]),
+    )
+    await this.setSettings({
+      ...this.settings,
+      lightRagExcludePatterns: merged,
+    })
+
+    // Remove any already-ingested docs for the excluded files from the graph
+    // so they disappear immediately.
+    const targetFiles: TFile[] = []
+    for (const file of files) {
+      if (file instanceof TFolder) {
+        targetFiles.push(...this.getAllSupportedFiles(file))
+      } else if (file instanceof TFile) {
+        targetFiles.push(file)
+      }
+    }
+
+    if (targetFiles.length === 0) {
+      new Notice('Excluded from graph sync')
+      return
+    }
+
+    const notice = new Notice('Removing excluded files from graph...', 0)
+    try {
+      const ragEngine = await this.getRAGEngine()
+      let removed = 0
+      for (const file of targetFiles) {
+        const ok = await ragEngine.deleteDocumentByFilePath(
+          file.path,
+          file.name,
+        )
+        if (ok) {
+          removed++
+          this.docIndexService?.setRemoved(file.path)
+        }
+      }
+      notice.setMessage(
+        removed > 0
+          ? `Excluded from graph sync (removed ${removed} file${
+              removed === 1 ? '' : 's'
+            } from graph)`
+          : 'Excluded from graph sync',
+      )
+    } catch (error) {
+      console.error('Error removing excluded files from graph:', error)
+      notice.setMessage('Excluded from graph sync (failed to update graph)')
+    } finally {
+      setTimeout(() => notice.hide(), 4000)
+    }
+  }
+
+  private async removeGraphExcludePatterns(patterns: string[]) {
+    const toRemove = new Set(patterns)
+    const remaining = this.settings.lightRagExcludePatterns.filter(
+      (pattern) => !toRemove.has(pattern),
+    )
+    await this.setSettings({
+      ...this.settings,
+      lightRagExcludePatterns: remaining,
+    })
+    new Notice(
+      'Re-included in graph sync. Edit the file to re-ingest it, or use "Ingest folder into graph".',
+    )
+  }
+
   async batchIngestFolder(folder: TFolder) {
-    const files = this.getAllSupportedFiles(folder)
+    const files = this.getAllSupportedFiles(folder).filter(
+      (file) => !this.isPathExcludedFromGraph(file.path),
+    )
     if (files.length === 0) {
       new Notice('Empty folder or no supported files.')
       return

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -121,6 +121,13 @@ export const NeuralComposerSettingsSchema = z.object({
 
   // --- INCREMENTAL SYNC ---
   lightRagSyncFolder: z.string().catch(''),
+
+  // --- GRAPH SYNC EXCLUSIONS ---
+  // Glob patterns (minimatch) for files/folders inside the watched folder that
+  // should never be ingested into the graph. `excludeHiddenFiles` additionally
+  // skips any path with a dot-prefixed segment (e.g. .trash, .obsidian).
+  lightRagExcludePatterns: z.array(z.string()).catch([]),
+  lightRagExcludeHiddenFiles: z.boolean().catch(true),
   // ----------------------------------
 })
 
@@ -202,6 +209,10 @@ export const DEFAULT_SETTINGS: NeuralComposerSettings = {
   // DEFAULT NUEVO
   lightRagCustomEnv: '',
   lightRagSyncFolder: '',
+
+  // GRAPH SYNC EXCLUSIONS
+  lightRagExcludePatterns: [],
+  lightRagExcludeHiddenFiles: true,
 }
 
 export type SettingMigration = {

--- a/src/settings/schema/settings.test.ts
+++ b/src/settings/schema/settings.test.ts
@@ -53,6 +53,8 @@ describe('parseNeuralComposerSettings', () => {
       lightRagCommand: 'lightrag-server',
       lightRagCustomEnv: '',
       lightRagEntityTypes: '',
+      lightRagExcludeHiddenFiles: true,
+      lightRagExcludePatterns: [],
       lightRagMaxAsync: 4,
       lightRagMaxParallelInsert: 1,
       lightRagOntologyFolder: '',

--- a/src/utils/glob-utils.test.ts
+++ b/src/utils/glob-utils.test.ts
@@ -1,0 +1,80 @@
+import {
+  getExcludePatternForPath,
+  isExcludedFromGraphSync,
+  isHiddenPath,
+} from './glob-utils'
+
+describe('getExcludePatternForPath', () => {
+  it('returns the exact path for a file', () => {
+    expect(getExcludePatternForPath('Research/todo.md', false)).toBe(
+      'Research/todo.md',
+    )
+  })
+
+  it('appends a recursive glob for a folder', () => {
+    expect(getExcludePatternForPath('Archive', true)).toBe('Archive/**')
+  })
+
+  it('appends a recursive glob for a nested folder', () => {
+    expect(getExcludePatternForPath('Work/Private', true)).toBe(
+      'Work/Private/**',
+    )
+  })
+})
+
+describe('isHiddenPath', () => {
+  it('detects a top-level hidden folder', () => {
+    expect(isHiddenPath('.trash/note.md')).toBe(true)
+  })
+
+  it('detects a nested hidden folder', () => {
+    expect(isHiddenPath('Research/.archive/old.md')).toBe(true)
+  })
+
+  it('detects a hidden file', () => {
+    expect(isHiddenPath('.secret-note.md')).toBe(true)
+  })
+
+  it('returns false for a regular path', () => {
+    expect(isHiddenPath('Research/2024/todo.md')).toBe(false)
+  })
+})
+
+describe('isExcludedFromGraphSync', () => {
+  const base = { excludePatterns: [], excludeHiddenFiles: true }
+
+  it('does not exclude a regular file by default', () => {
+    expect(isExcludedFromGraphSync('Research/todo.md', base)).toBe(false)
+  })
+
+  it('excludes hidden files when excludeHiddenFiles is true', () => {
+    expect(isExcludedFromGraphSync('.trash/note.md', base)).toBe(true)
+  })
+
+  it('does not exclude hidden files when excludeHiddenFiles is false', () => {
+    expect(
+      isExcludedFromGraphSync('.trash/note.md', {
+        ...base,
+        excludeHiddenFiles: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('excludes files matching a glob exclude pattern', () => {
+    expect(
+      isExcludedFromGraphSync('Research/Templates/daily.md', {
+        ...base,
+        excludePatterns: ['Research/Templates/**'],
+      }),
+    ).toBe(true)
+  })
+
+  it('does not exclude files outside the exclude patterns', () => {
+    expect(
+      isExcludedFromGraphSync('Research/keep.md', {
+        ...base,
+        excludePatterns: ['Research/Templates/**'],
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/utils/glob-utils.ts
+++ b/src/utils/glob-utils.ts
@@ -7,3 +7,44 @@ export const findFilesMatchingPatterns = (patterns: string[], vault: Vault) => {
     return patterns.some((pattern) => minimatch(file.path, pattern))
   })
 }
+
+/**
+ * Builds a glob exclude pattern for a vault path.
+ *
+ * Folders are expanded to match every descendant (`path/**`) so all files
+ * inside are excluded; files are matched by their exact path.
+ */
+export const getExcludePatternForPath = (
+  path: string,
+  isFolder: boolean,
+): string => {
+  return isFolder ? `${path}/**` : path
+}
+
+/**
+ * Returns true if any segment of the vault path starts with a dot, i.e. the
+ * file or one of its parent folders is hidden (e.g. `.trash/note.md`,
+ * `Research/.archive/old.md`).
+ */
+export const isHiddenPath = (path: string): boolean => {
+  return path.split('/').some((segment) => segment.startsWith('.'))
+}
+
+/**
+ * Decides whether a vault path is excluded from graph (LightRAG) ingestion.
+ *
+ * A path is excluded when hidden-file exclusion is enabled and the path is
+ * hidden, or when it matches any of the configured glob exclude patterns.
+ */
+export const isExcludedFromGraphSync = (
+  path: string,
+  {
+    excludePatterns,
+    excludeHiddenFiles,
+  }: { excludePatterns: string[]; excludeHiddenFiles: boolean },
+): boolean => {
+  if (excludeHiddenFiles && isHiddenPath(path)) {
+    return true
+  }
+  return excludePatterns.some((pattern) => minimatch(path, pattern))
+}


### PR DESCRIPTION
Closes #42

## Summary

Adds a blacklist so chosen files/folders inside the watched sync folder are never auto-ingested into the LightRAG graph. Useful for templates, scratch/inbox notes, and hidden/system files that live inside the watched folder but shouldn't end up in the graph.

## Changes

- **Settings** ([setting.types.ts](src/settings/schema/setting.types.ts)): `lightRagExcludePatterns` (glob list, `minimatch`) and `lightRagExcludeHiddenFiles` (default `true`; skips dot-prefixed paths like `.trash` / `.obsidian`). Added with zod `.catch` defaults, so existing configs migrate automatically.
- **Helper** ([glob-utils.ts](src/utils/glob-utils.ts)): `isExcludedFromGraphSync()`, `isHiddenPath()`, `getExcludePatternForPath()`.
- **Gating** ([main.ts](src/main.ts)): every auto-ingestion entry point — `create`, `modify`, rename-into-folder, and `batchIngestFolder` — skips excluded paths *before* any "processing" state/notice is shown. Defense-in-depth guard inside [`ragEngine.ingestFile()`](src/core/rag/ragEngine.ts). The explicit "Ingest current file" command is intentionally left as a manual override.
- **Context menu** ([main.ts](src/main.ts)): "Exclude from graph sync" for files and folders (single + multi-select) appends the pattern (`path/**` for folders, exact path for files) and removes any already-ingested docs for those files from the graph; toggles to "Re-include in graph sync".
- **Settings UI** ([NeuralSection.tsx](src/components/settings/sections/NeuralSection.tsx)): exclude-patterns textarea + hidden-files toggle, under "Vault sync".

## Testing

- New unit tests in [glob-utils.test.ts](src/utils/glob-utils.test.ts) (pattern building, hidden detection, exclusion logic) and updated [settings.test.ts](src/settings/schema/settings.test.ts) defaults.
- `npm test` (133 passed) and `npm run type:check` pass. Prettier passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)