### PR TITLE
Complete and observable folder removal for large folders

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -821,7 +821,10 @@ export default class NeuralComposerPlugin extends Plugin {
   }
 
   // --- MONITORING LOGIC ---
-  async monitorPipeline(notice: Notice) {
+  async monitorPipeline(
+    notice: Notice,
+    doneMessage = 'Integrated knowledge!\nThe graph is up to date.',
+  ) {
     this.updateStatusUI('busy')
     let isBusy = true
     let errors = 0
@@ -838,6 +841,7 @@ export default class NeuralComposerPlugin extends Plugin {
 
         type PipelineStatus = {
           busy: boolean
+          job_name?: string
           batchs?: number
           cur_batch?: number
           latest_message?: string
@@ -849,9 +853,12 @@ export default class NeuralComposerPlugin extends Plugin {
           const total = status.batchs || 1
           const current = status.cur_batch || 0
           const percent = Math.round((current / total) * 100)
+          // job_name distinguishes deletion ("Deleting N Documents") from
+          // ingestion so the header reflects what the server is actually doing.
+          const header = status.job_name || 'System processing...'
 
           notice.setMessage(
-            `System processing...\n` +
+            `${header}\n` +
               `Progress: ${percent}% (${current}/${total})\n` +
               `📝 ${status.latest_message || 'Analyzing...'}`,
           )
@@ -869,8 +876,48 @@ export default class NeuralComposerPlugin extends Plugin {
     }
 
     this.updateStatusUI('online')
-    notice.setMessage('Integrated knowledge!\nThe graph is up to date.')
+    notice.setMessage(doneMessage)
     window.setTimeout(() => notice.hide(), 5000)
+  }
+
+  /**
+   * Poll /documents/pipeline_status until the server is idle. Used to serialize
+   * bulk deletes: LightRAG runs one deletion job at a time and drops delete
+   * requests received while it's busy, so callers must wait for each batch to
+   * drain before sending the next. `onBusy` receives the live status on each
+   * poll where the pipeline is busy (for progress UI).
+   */
+  private async waitForPipelineIdle(
+    onBusy?: (status: Record<string, unknown>) => void,
+    maxMs = 60 * 60 * 1000,
+  ): Promise<void> {
+    const start = Date.now()
+    // Grace period so we don't read `busy:false` before the job registers.
+    await new Promise((r) => window.setTimeout(r, 1500))
+    let idleReads = 0
+    let errors = 0
+    while (Date.now() - start < maxMs) {
+      try {
+        const response = await requestUrl({
+          url: `${this.settings.lightRagServerUrl}/documents/pipeline_status`,
+          method: 'GET',
+          headers: this.getLightRagHeaders(),
+          throw: false,
+        })
+        const status = response.json as Record<string, unknown>
+        if (status.busy) {
+          idleReads = 0
+          onBusy?.(status)
+        } else if (++idleReads >= 2) {
+          // Two consecutive idle reads → this batch has finished on the server.
+          return
+        }
+        errors = 0
+      } catch {
+        if (++errors > 5) return
+      }
+      await new Promise((r) => window.setTimeout(r, 2000))
+    }
   }
 
   // --- BATCH LOGIC ---
@@ -1076,7 +1123,7 @@ export default class NeuralComposerPlugin extends Plugin {
     )
   }
 
-  async batchRemoveFolderFromGraph(folder: TFolder) {
+  batchRemoveFolderFromGraph(folder: TFolder) {
     const files = this.getAllSupportedFiles(folder)
     if (files.length === 0) {
       new Notice('Empty folder or no supported files.')
@@ -1106,40 +1153,74 @@ export default class NeuralComposerPlugin extends Plugin {
 
     try {
       const ragEngine = await this.getRAGEngine()
+
+      // Resolve every doc_id in ONE pagination pass (the document list spans
+      // multiple pages on large vaults), then delete in batches.
+      notice.setMessage('Looking up documents in graph…')
+      const idMap = await ragEngine.getDocIdMap()
+      const toDelete: { docId: string; path: string }[] = []
+      for (const file of files) {
+        const docId = idMap.get(file.path) ?? idMap.get(file.name)
+        if (docId) toDelete.push({ docId, path: file.path })
+      }
+      const missing = files.length - toDelete.length
+      const tail = missing > 0 ? ` (${missing} not in graph)` : ''
+
+      if (toDelete.length === 0) {
+        notice.setMessage(
+          missing > 0
+            ? `Nothing removed — ${missing} file(s) were not in the graph.`
+            : 'Nothing to remove.',
+        )
+        window.setTimeout(() => notice.hide(), 5000)
+        return
+      }
+
+      // Delete in chunks, SEQUENTIALLY. LightRAG runs one deletion job at a
+      // time and drops delete requests received while it's busy, so firing all
+      // chunks at once would only delete the first. We send a chunk, wait for
+      // the server pipeline to drain, then send the next. Deletion is also slow
+      // (the entity graph is reprocessed per document), so we surface live
+      // per-batch progress in the notice.
+      const CHUNK = 100
+      const totalBatches = Math.ceil(toDelete.length / CHUNK)
       let removed = 0
-      let missing = 0
-
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i]
-        notice.setMessage(`Removing (${i + 1}/${files.length}):\n${file.name}`)
-        try {
-          const ok = await ragEngine.deleteDocumentByFilePath(
-            file.path,
-            file.name,
-          )
-          if (ok) {
-            removed++
-            if (isInWatchedFolder(file.path)) {
-              this.docIndexService?.setRemoved(file.path)
+      for (let b = 0; b < totalBatches; b++) {
+        const batch = toDelete.slice(b * CHUNK, b * CHUNK + CHUNK)
+        notice.setMessage(
+          `Removing from "${folder.path}"${tail}\n` +
+            `Batch ${b + 1}/${totalBatches} — sending ${batch.length}…`,
+        )
+        const ok = await ragEngine.deleteDocumentsByIds(
+          batch.map((x) => x.docId),
+        )
+        if (ok) {
+          removed += batch.length
+          for (const x of batch) {
+            if (isInWatchedFolder(x.path)) {
+              this.docIndexService?.setRemoved(x.path)
             }
-          } else {
-            missing++
           }
-        } catch (err) {
-          console.error(`Error removing ${file.name}:`, err)
-          missing++
         }
+        this.updateStatusUI('busy')
+        await this.waitForPipelineIdle((status) => {
+          const cur = (status.cur_batch as number) || 0
+          const tot = (status.batchs as number) || batch.length
+          const pct = Math.round((cur / Math.max(tot, 1)) * 100)
+          notice.setMessage(
+            `Removing from "${folder.path}"${tail}\n` +
+              `Batch ${b + 1}/${totalBatches} · ${pct}%\n` +
+              `📝 ${(status.latest_message as string) || 'Processing…'}`,
+          )
+        })
       }
 
-      if (removed > 0) {
-        void this.refreshIngestedFolderPaths()
-      }
-
+      this.updateStatusUI('online')
       notice.setMessage(
-        `Removed ${removed} from "${folder.path}"` +
-          (missing > 0 ? ` (${missing} not in graph)` : ''),
+        `Removed ${removed} from "${folder.path}"${tail}.\nReopen the graph view to refresh.`,
       )
-      window.setTimeout(() => notice.hide(), 4000)
+      window.setTimeout(() => notice.hide(), 6000)
+      void this.refreshIngestedFolderPaths()
       this.decorateFileExplorer()
     } catch (error) {
       console.error('Batch remove error:', error)


### PR DESCRIPTION
## Summary

Removing a large folder from the graph silently stopped after ~100 documents. LightRAG runs one deletion job at a time and ignores delete requests received while it's busy, but the removal loop deleted one file per request with no coordination — so on a big folder the server only processed the first burst before the loop reported "done".

- Resolve every `doc_id` in a single pagination pass (`getDocIdMap`), then delete in chunks of 100 via `deleteDocumentsByIds`.
- Send each chunk only after the server pipeline drains (`waitForPipelineIdle`), so every chunk is actually processed instead of dropped.
- Surface live per-batch progress in the notice (batch N/M, percent, and the server's latest status message), since per-document entity-graph reprocessing makes large deletions slow.
- `monitorPipeline` gains an optional `doneMessage` and now shows the server `job_name`, so the same poller reads correctly for deletion as well as ingestion.

Single file changed (`src/main.ts`).